### PR TITLE
Improve error messages and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A C compiler written in POSIX shell and generating POSIX shell scripts
 
 ## How to use
 
-The `cc.sh` compiler takes a C file path as input, and outputs the stdout the
+The `cc.sh` compiler takes a C file path as input, and outputs to stdout the
 compiled shell code. In case of compilation error, it outputs to stderr the
 error message.
 
@@ -15,4 +15,5 @@ To compile and run: `./cc.sh test.c > test.sh && ./test.sh`
 - #include macros
 - macros with arguments
 - sizeof
-- struct
+- struct/unions
+- string subexpressions

--- a/cc.sh
+++ b/cc.sh
@@ -599,15 +599,15 @@ parse_postfix_expression()
         ;;
 
       '.')
-        syntax_error "TODO 222"
+        syntax_error "Struct/Union not supported"
         ;;
 
       '->')
-        syntax_error "TODO 333"
+        syntax_error "Struct/Union not supported"
         ;;
 
       '++'|'--')
-        syntax_error "TODO 444"
+        syntax_error "++/-- not supported"
         ;;
 
       *)


### PR DESCRIPTION
## Context

I like to use the following command with a file watcher as a way to get quick feedback on my changes: `./cc.sh test.c > test.sh && test.sh`. Unfortunately, not all errors were thrown with status code 1, making this difficult to use.

This PR replaces the all calls to `exit` to `missing_feature_error` and redirects its error message (along with the error message of `syntax_error`) to stderr and adds some basic how-to-run instructions to the README.