### PR TITLE
Support stringizing and token pasting

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -68,6 +68,7 @@ void print_tok(int tok, int val) {
   else if (tok == RSHIFT) printf(">>");
   else if (tok == SLASH_EQ) printf("/=");
   else if (tok == STAR_EQ) printf("*=");
+  else if (tok == HASH_HASH) printf("##");
 
   else if (tok == IDENTIFIER) {
     printf("%s", string_pool + heap[val+1]);


### PR DESCRIPTION
## Context

TCC uses token pasting and token stringizing in a few macros. Most of these uses are relatively simple, token pasting between 2 identifiers and stringizing identifiers. This PR adds support for both. It also adds support for continuous strings as stringizing relies on it, and fixes a few bugs.