### PR TITLE
Support casts expressions

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -618,8 +618,10 @@ ast value_type(ast node) {
         putchar('\n');
         fatal_error("value_type: function not found");
       }
+    } else if (op == CAST) {
+      return get_child(node, 0);
     } else {
-      fatal_error("value_type: unknown expression");
+      fatal_error("value_type: unknown expression with 2 children");
     }
 
   } else if (nb_children == 3) {
@@ -842,7 +844,7 @@ int codegen_lvalue(ast node) {
       codegen_binop('+', get_child(node, 0), get_child(node, 1));
       grow_fs(-2);
     } else {
-      fatal_error("codegen_lvalue: unknown lvalue");
+      fatal_error("codegen_lvalue: unknown lvalue with 2 children");
     }
 
   } else {
@@ -1053,8 +1055,10 @@ void codegen_rvalue(ast node) {
       def_label(lbl1);
     } else if (op == '(') {
       codegen_call(node);
+    } else if (op == CAST) {
+      codegen_rvalue(get_child(node, 1));
     } else {
-      fatal_error("codegen_rvalue: unknown rvalue");
+      fatal_error("codegen_rvalue: unknown rvalue with 2 children");
     }
 
   } else if (nb_children == 3) {

--- a/pnut.c
+++ b/pnut.c
@@ -89,6 +89,7 @@ enum {
   VAR_DECL,
   VAR_DECLS,
   FUN_DECL,
+  CAST,
 
   // Non-character operands
   INTEGER    = 401,
@@ -913,11 +914,15 @@ void push_macro(int tokens, int args) {
       macro_stack[macro_stack_ix] = macro_tok_lst;
       macro_stack[macro_stack_ix + 1] = macro_args;
       macro_stack_ix += 2;
-    } else {
     }
+
     macro_tok_lst = tokens;
     macro_args = args;
   }
+}
+
+void push_tokens(int tokens) {
+  push_macro(tokens, 0);
 }
 
 // Try to expand a macro.
@@ -1930,7 +1935,7 @@ ast parse_unary_expression() {
   ast result;
   int op;
 
-  if (tok == PLUS_PLUS){
+  if (tok == PLUS_PLUS) {
 
     get_tok();
     result = parse_unary_expression();
@@ -1961,6 +1966,49 @@ ast parse_unary_expression() {
 }
 
 ast parse_cast_expression() {
+  int parens = 0;
+  int tokens = 0;
+  ast result;
+  ast type;
+  int stars;
+
+  if (tok == '(') {
+    // Ideally, we'd parse as many ( as needed, but then we would have to
+    // backtrack when the first parenthesis is for a parenthesized expression
+    // and not a cast.
+    // I think we could write a version of parse_parenthesized_expression that
+    // already has the first parenthesis consumed. It would be called when
+    // after parsing the cast and cast expression, there are still parenthesis
+    // to close, but I'm not sure how we could create the AST since it's all
+    // very top down and that would flip the order of the AST creation.
+
+    // Concretely, this means we can't parse cast expressions where the type
+    // is wrapped in parenthesis, like in the following example:
+    // (((char *)) var)
+    // But that should be ok for TCC.
+    get_tok();
+
+    if (is_type_starter(tok)) {
+      type = parse_type();
+      stars = parse_stars();
+      set_val(type, stars);
+      // TODO: Import clone_ast from other branch
+      // if (stars != 0) {
+      //   type = clone_ast(type);
+      // }
+
+      expect_tok(')');
+      result = new_ast2(CAST, type, parse_cast_expression());
+      return result;
+    } else {
+      // We need to put the current token and '(' back on the token stream.
+      tokens = cons(cons(tok, val), 0);
+      push_tokens(tokens);
+      tok = '(';
+      val = 0;
+    }
+  }
+
   return parse_unary_expression();
 }
 

--- a/sh.c
+++ b/sh.c
@@ -788,6 +788,8 @@ ast handle_side_effects_go(ast node, int executes_conditionally) {
       right_conditional_fun_calls = conditional_fun_calls;
       conditional_fun_calls = previous_conditional_fun_calls;
       return new_ast4(op, sub1, sub2, left_conditional_fun_calls, right_conditional_fun_calls);
+    } else if (op == CAST) {
+      return new_ast2(CAST, get_child(node, 0), handle_side_effects_go(get_child(node, 1), executes_conditionally));
     } else {
       printf("2: op=%d %c", op, op);
       fatal_error("unexpected operator");
@@ -976,11 +978,13 @@ text comp_rvalue_go(ast node, int context, ast test_side_effects) {
         sub2 = comp_rvalue_go(get_child(node, 1), RVALUE_CTX_ARITH_EXPANSION, 0);
         return wrap_if_needed(true, context, test_side_effects, string_concat3(sub1, op_to_str(op), sub2));
       }
+    } else if (op == CAST) { // Casts are no-op
+      return comp_rvalue_go(get_child(node, 1), RVALUE_CTX_ARITH_EXPANSION, 0);
     } else if (op == AMP_AMP OR op == BAR_BAR) {
       fatal_error("comp_rvalue_go: && and || should have 4 children by that point");
       return 0;
     } else {
-      fatal_error("comp_rvalue_go: unknown rvalue");
+      fatal_error("comp_rvalue_go: unknown rvalue with 2 children");
       return 0;
     }
   } else if (nb_children == 3) {
@@ -1157,6 +1161,8 @@ text comp_array_lvalue(ast node) {
     sub1 = comp_array_lvalue(get_child(node, 0));
     sub2 = comp_rvalue(get_child(node, 1), RVALUE_CTX_ARITH_EXPANSION);
     return string_concat5(wrap_str("_$(("), sub1, wrap_char('+'), sub2, wrap_str("))"));
+  } else if (op == CAST) {
+    return comp_lvalue(get_child(node, 1));
   } else {
     printf("op=%d %c\n", op, op);
     fatal_error("comp_array_lvalue: unknown lvalue");
@@ -1177,7 +1183,9 @@ text comp_lvalue(ast node) {
     return string_concat5(wrap_str("_$(("), sub1, wrap_char('+'), sub2, wrap_str("))"));
   } else if (op == '*') {
     sub1 = comp_rvalue(get_child(node, 0), RVALUE_CTX_BASE);
-    return string_concat(wrap_char('_'), sub1);
+    return string_concat3(wrap_str("_$(("), sub1, wrap_str("))"));
+  } else if (op == CAST) {
+    return comp_lvalue(get_child(node, 1));
   } else {
     printf("op=%d %c\n", op, op);
     fatal_error("comp_lvalue: unknown lvalue");


### PR DESCRIPTION
## Context

Casts are used by throughout TCC and can't easily be avoided. This PR adds support for them, with the caveat that the parser only accepts casts where the type is not wrapped in redundant parenthesis. This is because the C grammar is a bit ambiguous and with the current parser we have, would require backtracking, which is hard to do in the general case with our current abstractions.

Still, I believe TCC doesn't use redundant parenthesis in its casts, and if it does, only in a few places so it will be easy to work around.