### PR TITLE
Support K&R param syntax in function definition

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -1591,6 +1591,12 @@ ast parse_declaration() {
     */
 
     result = new_ast3(VAR_DECL, name, type, 0);
+  } else if (tok == IDENTIFIER) {
+    // Support K&R param syntax in function definition
+    name = val;
+    expect_tok(IDENTIFIER);
+    type = new_ast0(INT_KW, 0);
+    result = new_ast3(VAR_DECL, name, type, 0);
   }
 
   return result;


### PR DESCRIPTION
## Context 

The earliest versions of TCC used K&R style for certain functions. This PR adds support for it, as it only takes a few lines. When we get to bootstrapping the latest versions of TCC, we'll be able to remove this small change to the parser.