### PR TITLE
Support #include <filename>

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -1,12 +1,9 @@
-#ifndef PNUT_CC
-
+// Those includes are parsed by pnut but ignored
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
-
-#endif
 
 #define ast int
 #define true 1
@@ -573,16 +570,24 @@ void handle_define() {
 
 void handle_include() {
   get_tok();
+  #ifdef SUPPORT_INCLUDE
   if (tok == STRING) {
-    #ifdef SUPPORT_INCLUDE
     include_file(string_pool + val);
-    #else
-    fatal_error("The #include directive is not supported in this version of the compiler.");
-    #endif
+  } else if (tok == '<') {
+    get_tok();
+    // Ignore the file name for now.
+    // Note that the token is not a string with the file name, but an identifier
+    // with part of the file. This means we'll need to assemble the filename
+    // string, or change get_tok to consider '<' and '>' as string delimiters.
+    while (tok != '>') get_tok();
   } else {
     putstr("tok="); putint(tok); putchar('\n');
     fatal_error("expected string to #include directive");
   }
+
+  #else
+  fatal_error("The #include directive is not supported in this version of the compiler.");
+  #endif
 }
 
 void handle_preprocessor_directive() {


### PR DESCRIPTION
## Context

Instead of having to hide `#include <filename>` directives, we want to parse them but do nothing. Eventually, we'll probably want to revisit this when/if we can compile standard library files, but for now we implicitly include a runtime library, so those includes can simply be ignored.