### PR TITLE
Don't print newline for null glo decls

### DIFF
--- a/sh.c
+++ b/sh.c
@@ -268,13 +268,15 @@ void print_glo_decls() {
   int level;
   while (i < glo_decl_ix) {
     if (glo_decls[i + 1] == 1) { /* Skip inactive declarations */
-      level = glo_decls[i];
-      while (level > 0) {
-        putchar(' '); putchar(' ');
-        level -= 1;
+      if (glo_decls[i + 2] != 0) {
+        level = glo_decls[i];
+        while (level > 0) {
+          putchar(' '); putchar(' ');
+          level -= 1;
+        }
+        print_text(glo_decls[i + 2]);
+        putchar('\n');
       }
-      print_text(glo_decls[i + 2]);
-      putchar('\n');
     }
     i += 3;
   }


### PR DESCRIPTION
## Context

Functions that end up not needing to call `save_vars`/`unsave_vars` had newlines in their place. This looks bad, especially for small functions because the whitespace takes as much space as the rest of the code:

```shell

_begin_string() {
  
  _string_start=$_string_pool_alloc
  _hash=0
  
}
```

This PR skips those empty lines so we no longer see the space reserved for `save_vars`/`unsave_vars`.