### PR TITLE
Fix shell pre/post increment not appearing

### DIFF
--- a/sh.c
+++ b/sh.c
@@ -715,8 +715,11 @@ ast handle_side_effects_go(ast node, int executes_conditionally) {
       return 0;
     }
   } else if (nb_children == 1) {
-    if ((op == '&') OR (op == '*') OR (op == '+') OR (op == '-') OR (op == '~') OR (op == '!') OR (op == PLUS_PLUS_PRE) OR (op == MINUS_MINUS_PRE) OR (op == PLUS_PLUS_POST) OR (op == MINUS_MINUS_POST)) {
+    if ((op == '&') OR (op == '*') OR (op == '+') OR (op == '-') OR (op == '~') OR (op == '!')) {
       /* TODO: Reuse ast node? */
+      return new_ast1(op, handle_side_effects_go(get_child(node, 0), executes_conditionally));
+    } else if (op == PLUS_PLUS_PRE || op == MINUS_MINUS_PRE || op == PLUS_PLUS_POST || op == MINUS_MINUS_POST) {
+      contains_side_effects = true;
       return new_ast1(op, handle_side_effects_go(get_child(node, 0), executes_conditionally));
     } else {
       printf("1: op=%d %c", op, op);
@@ -1499,6 +1502,8 @@ void comp_statement(ast node, int else_if) {
     str = comp_rvalue(node, RVALUE_CTX_BASE);
     if (contains_side_effects) {
       append_glo_decl(string_concat(wrap_str(": "), str));
+    } else if (in_block_head_position && in_tail_position) {
+      append_glo_decl(wrap_str(":")); /* Block only contains this statement so we have to make sure it's not empty */
     }
   }
 }


### PR DESCRIPTION
Tried to use ++ and -- in shell and it wasn't working. It looks like we forgot to set `contains_side_effects = true` for these operators.

This bug revealed another bug where the a basic block with an arithmetic statement without side effect can cause the block to be empty, which is a syntax error.