### PR TITLE
Implement callee-save calling convention with set command

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -16,7 +16,8 @@
 
 #define AVOID_AMPAMP_BARBAR_not
 
-#define OPTIMIZE_CONSTANT_PARAM_not
+// Use positional parameter directly for function parameters that are constants
+#define OPTIMIZE_CONSTANT_PARAM
 #define SUPPORT_ADDRESS_OF_OP_not
 
 // Shell backend codegen options
@@ -26,6 +27,8 @@
 #define SH_INLINE_EXIT
 // Specifies if we include the C code along with the generated shell code
 #define SH_INCLUDE_C_CODE_not
+// If we use the `set` command and positional parameters to simulate local vars
+#define SH_SAVE_VARS_WITH_SET
 
 // Options to parameterize the shell runtime library
 #define RT_FREE_UNSETS_VARS

--- a/sh-runtime.c
+++ b/sh-runtime.c
@@ -70,8 +70,9 @@ RETURN_IF_TRUE(runtime_ ## name ## _defined)
 
 DEFINE_RUNTIME_FUN(local_vars)
   printf("# Local variables\n");
-  printf("__SP=0\n");
   printf("__=0\n");
+#ifndef SH_SAVE_VARS_WITH_SET
+  printf("__SP=0\n");
 #ifdef SH_INDIVIDUAL_LET
   printf("let() { : $((__SP += 1)) $((__$__SP=$1)); } \n");
 #else
@@ -82,6 +83,7 @@ DEFINE_RUNTIME_FUN(local_vars)
   printf("  while [ $# -ge 2 ]; do : $(($2 = __$__SP)) $((__SP -= 1)); shift; done\n");
   printf("  : $(($__ret=__tmp))\n");
   printf("}\n");
+#endif
 END_RUNTIME_FUN(local_vars)
 
 // char<->int conversion


### PR DESCRIPTION
## Context

We can use positional parameters to implement our callee-save calling convention. Since this uses the built-in mechanism for local variables instead of a stack managed in shell, this is much faster. The pnut-sh bootstrap on ksh goes from 30s to 17s.

## Example on fib

### With `OPTIMIZE_CONSTANT_PARAM` and `SH_SAVE_VARS_WITH_SET`:

```shell
_fib() { # n: $2
  set $1 $2 $__g1 $__g2
  if [ $2 -lt 2 ] ; then
    : $(( $1 = $2 ))
    : $((_tmp = $1)); __g1=$3; __g2=$4; : $(($1 = _tmp))
    return
  fi
  _fib __g1 $(($2 - 1))
  _fib __g2 $(($2 - 2))
  : $(( $1 = (__g1 + __g2) ))
  : $((_tmp = $1)); __g1=$3; __g2=$4; : $(($1 = _tmp))
}
```

```
ksh  examples/fib.sh  0.12s user 0.00s system 98% cpu 0.122 total
bash examples/fib.sh  0.36s user 0.01s system 98% cpu 0.378 total
dash examples/fib.sh  0.12s user 0.03s system 98% cpu 0.158 total
zsh  examples/fib.sh  0.20s user 0.10s system 98% cpu 0.305 total
```

### With `SH_SAVE_VARS_WITH_SET`:

```shell
_fib() { # n: $2
  set $1 $2 $n $__g1 $__g2
  n=$2
  if [ $n -lt 2 ] ; then
    : $(( $1 = n ))
    : $((_tmp = $1)); n="$3"; __g1=$4; __g2=$5; : $(($1 = _tmp))
    return
  fi
  _fib __g1 $((n - 1))
  _fib __g2 $((n - 2))
  : $(( $1 = (__g1 + __g2) ))
  : $((_tmp = $1)); n="$3"; __g1=$4; __g2=$5; : $(($1 = _tmp))
}
```

```
ksh  examples/fib.sh  0.13s user 0.00s system 98% cpu 0.130 total
bash examples/fib.sh  0.42s user 0.01s system 99% cpu 0.434 total
dash examples/fib.sh  0.14s user 0.04s system 97% cpu 0.186 total
zsh  examples/fib.sh  0.22s user 0.10s system 98% cpu 0.324 total
```

### With `SH_INDIVIDUAL_LET`:

```shell
_fib() { # n: $2
  let n; let __g1; let __g2
  n=$2
  if [ $n -lt 2 ] ; then
    : $(( $1 = n ))
    endlet $1 __g2 __g1 n
    return
  fi
  _fib __g1 $((n - 1))
  _fib __g2 $((n - 2))
  : $(( $1 = (__g1 + __g2) ))
  endlet $1 __g2 __g1 n
}
```

```
ksh  examples/fib.sh  0.42s user 0.00s system 99% cpu 0.424 total
bash examples/fib.sh  1.10s user 0.01s system 98% cpu 1.119 total
dash examples/fib.sh  0.39s user 0.08s system 99% cpu 0.474 total
zsh  examples/fib.sh  0.69s user 0.38s system 99% cpu 1.068 total
```

### Default: 

```shell
_fib() { # n: $2
  let n __g1 __g2
  n=$2
  if [ $n -lt 2 ] ; then
    : $(( $1 = n ))
    endlet $1 __g2 __g1 n
    return
  fi
  _fib __g1 $((n - 1))
  _fib __g2 $((n - 2))
  : $(( $1 = (__g1 + __g2) ))
  endlet $1 __g2 __g1 n
}
````

```
ksh  examples/fib.sh  0.44s user 0.00s system 99% cpu 0.443 total
bash examples/fib.sh  1.19s user 0.01s system 99% cpu 1.211 total
dash examples/fib.sh  0.48s user 0.09s system 99% cpu 0.571 total
zsh  examples/fib.sh  0.78s user 0.33s system 99% cpu 1.124 total
```