### PR TITLE
Fix RT_USE_LOOKUP_TABLE when reading unicode chars

### DIFF
--- a/examples/compiled/all-chars.sh
+++ b/examples/compiled/all-chars.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((c = 0))
 _main() {

--- a/examples/compiled/base64.sh
+++ b/examples/compiled/base64.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 __ALLOC=1 # Starting heap at 1 because 0 is the null pointer.
 
@@ -46,7 +47,7 @@ unpack_escaped_string() {
         __buf="${__buf#?}" # Remove the current char from $__buf
         ;;
       *)
-        __c=$(LC_CTYPE=C printf "%d" "'${__buf%"${__buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+        __c=$(printf "%d" "'${__buf%"${__buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
         __buf="${__buf#?}" # Remove the current char from $__buf
         ;;
     esac
@@ -190,7 +191,7 @@ _getchar() {
       fi
     fi
   fi
-  __c=$(LC_CTYPE=C printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+  __c=$(printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
   : $(($1 = __c))
     __stdin_buf="${__stdin_buf#?}"                  # remove the current char from $__stdin_buf
 }
@@ -206,7 +207,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/cat.sh
+++ b/examples/compiled/cat.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 __ALLOC=1 # Starting heap at 1 because 0 is the null pointer.
 
@@ -78,7 +79,7 @@ unpack_line() { # $1: Shell string, $2: Buffer, $3: Ends with EOF?
   __buffer=$2
   __ends_with_eof=$3
   while [ ! -z "$__fgetc_buf" ]; do
-    __c=$(LC_CTYPE=C printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
     : $((_$__buffer = __c))
     __fgetc_buf=${__fgetc_buf#?}      # Remove the first character
     : $((__buffer += 1))              # Move to the next buffer position
@@ -272,7 +273,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/cp.sh
+++ b/examples/compiled/cp.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((filename = 0))
 _file_error() { let filename $2
@@ -71,7 +72,7 @@ unpack_line() { # $1: Shell string, $2: Buffer, $3: Ends with EOF?
   __buffer=$2
   __ends_with_eof=$3
   while [ ! -z "$__fgetc_buf" ]; do
-    __c=$(LC_CTYPE=C printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
     : $((_$__buffer = __c))
     __fgetc_buf=${__fgetc_buf#?}      # Remove the first character
     : $((__buffer += 1))              # Move to the next buffer position
@@ -251,7 +252,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/echo.sh
+++ b/examples/compiled/echo.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((i = argv_ = argc = 0))
 _main() { let argc $2; let argv_ $3
@@ -44,7 +45,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/empty.sh
+++ b/examples/compiled/empty.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 _main() {
   :

--- a/examples/compiled/fib.sh
+++ b/examples/compiled/fib.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((__t2 = __t1 = n = 0))
 _fib() { let n $2

--- a/examples/compiled/hello.sh
+++ b/examples/compiled/hello.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 _main() {
   printf "Hello, world\n"

--- a/examples/compiled/print-reverse.sh
+++ b/examples/compiled/print-reverse.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((i = len = tmp = end = str = 0))
 _reverse_str() { let str $2
@@ -62,7 +63,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/repl.sh
+++ b/examples/compiled/repl.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 __ALLOC=1 # Starting heap at 1 because 0 is the null pointer.
 
@@ -37,7 +38,7 @@ unpack_escaped_string() {
         __buf="${__buf#?}" # Remove the current char from $__buf
         ;;
       *)
-        __c=$(LC_CTYPE=C printf "%d" "'${__buf%"${__buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+        __c=$(printf "%d" "'${__buf%"${__buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
         __buf="${__buf#?}" # Remove the current char from $__buf
         ;;
     esac
@@ -781,7 +782,7 @@ unpack_line() { # $1: Shell string, $2: Buffer, $3: Ends with EOF?
   __buffer=$2
   __ends_with_eof=$3
   while [ ! -z "$__fgetc_buf" ]; do
-    __c=$(LC_CTYPE=C printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
     : $((_$__buffer = __c))
     __fgetc_buf=${__fgetc_buf#?}      # Remove the first character
     : $((__buffer += 1))              # Move to the next buffer position

--- a/examples/compiled/reverse.sh
+++ b/examples/compiled/reverse.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((i = argv_ = argc = 0))
 _main() { let argc $2; let argv_ $3
@@ -43,7 +44,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/select-file.sh
+++ b/examples/compiled/select-file.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 ################################################################################
 #
@@ -224,7 +225,7 @@ _getchar() {
       fi
     fi
   fi
-  __c=$(LC_CTYPE=C printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+  __c=$(printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
   : $(($1 = __c))
     __stdin_buf="${__stdin_buf#?}"                  # remove the current char from $__stdin_buf
 }
@@ -298,7 +299,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/sha256sum.sh
+++ b/examples/compiled/sha256sum.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 __ALLOC=1 # Starting heap at 1 because 0 is the null pointer.
 
@@ -262,7 +263,7 @@ unpack_escaped_string() {
         __buf="${__buf#?}" # Remove the current char from $__buf
         ;;
       *)
-        __c=$(LC_CTYPE=C printf "%d" "'${__buf%"${__buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+        __c=$(printf "%d" "'${__buf%"${__buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
         __buf="${__buf#?}" # Remove the current char from $__buf
         ;;
     esac
@@ -300,7 +301,7 @@ unpack_line() { # $1: Shell string, $2: Buffer, $3: Ends with EOF?
   __buffer=$2
   __ends_with_eof=$3
   while [ ! -z "$__fgetc_buf" ]; do
-    __c=$(LC_CTYPE=C printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
     : $((_$__buffer = __c))
     __fgetc_buf=${__fgetc_buf#?}      # Remove the first character
     : $((__buffer += 1))              # Move to the next buffer position
@@ -484,7 +485,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/sum-array.sh
+++ b/examples/compiled/sum-array.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((sum = i = size = n = 0))
 _sum_array() { let n $2; let size $3

--- a/examples/compiled/wc-stdin.sh
+++ b/examples/compiled/wc-stdin.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((c = 0))
 _is_word_separator() { let c $2
@@ -61,7 +62,7 @@ _getchar() {
       fi
     fi
   fi
-  __c=$(LC_CTYPE=C printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+  __c=$(printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
   : $(($1 = __c))
     __stdin_buf="${__stdin_buf#?}"                  # remove the current char from $__stdin_buf
 }

--- a/examples/compiled/wc.sh
+++ b/examples/compiled/wc.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 __ALLOC=1 # Starting heap at 1 because 0 is the null pointer.
 
@@ -112,7 +113,7 @@ unpack_line() { # $1: Shell string, $2: Buffer, $3: Ends with EOF?
   __buffer=$2
   __ends_with_eof=$3
   while [ ! -z "$__fgetc_buf" ]; do
-    __c=$(LC_CTYPE=C printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'${__fgetc_buf%"${__fgetc_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
     : $((_$__buffer = __c))
     __fgetc_buf=${__fgetc_buf#?}      # Remove the first character
     : $((__buffer += 1))              # Move to the next buffer position
@@ -296,7 +297,7 @@ unpack_string() {
     # Remove all but first char
     __char="${__str%"$__tail"}"
     # Convert char to ASCII
-    __c=$(LC_CTYPE=C printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
+    __c=$(printf "%d" "'$__char"); __c=$((__c > 0 ? __c : 256 + __c))
     # Write character to memory
     : $((_$__ptr = __c))
     # Continue with rest of string

--- a/examples/compiled/welcome.sh
+++ b/examples/compiled/welcome.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 : $((__t1 = i = name = 0))
 _main() {
@@ -47,7 +48,7 @@ _getchar() {
       fi
     fi
   fi
-  __c=$(LC_CTYPE=C printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
+  __c=$(printf "%d" "'${__stdin_buf%"${__stdin_buf#?}"}"); __c=$((__c > 0 ? __c : 256 + __c))
   : $(($1 = __c))
     __stdin_buf="${__stdin_buf#?}"                  # remove the current char from $__stdin_buf
 }

--- a/examples/compiled/winterpi.sh
+++ b/examples/compiled/winterpi.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e -u
+LC_ALL=C
 
 __ALLOC=1 # Starting heap at 1 because 0 is the null pointer.
 

--- a/sh-runtime.c
+++ b/sh-runtime.c
@@ -16,7 +16,7 @@ RETURN_IF_TRUE(runtime_ ## name ## _defined)
 #define RETURN_IF_TRUE(var) if (var) return; var = true;
 
 #ifdef RT_COMPACT
-#define call_char_to_int(prefix, char_var) putstr(prefix "__c=$(LC_CTYPE=C printf \"%d\" \"'" char_var "\"); __c=$((__c > 0 ? __c : 256 + __c))\n");
+#define call_char_to_int(prefix, char_var) putstr(prefix "__c=$(printf \"%d\" \"'" char_var "\"); __c=$((__c > 0 ? __c : 256 + __c))\n");
 #else
 #define call_char_to_int(prefix, char_var) putstr(prefix "char_to_int \"" char_var "\"\n");
 #endif
@@ -371,7 +371,7 @@ DEFINE_RUNTIME_FUN(char_to_int)
   putstr("    '}') __c=125 ;;\n");
   putstr("    '~') __c=126 ;;\n");
   putstr("    *)\n");
-  putstr("      __c=$(LC_CTYPE=C printf \"%d\" \"'$1\"); __c=$((__c > 0 ? __c : 256 + __c)) ;; \n");
+  putstr("      __c=$(printf \"%d\" \"'$1\"); __c=$((__c > 0 ? __c : 256 + __c)) ;; \n");
   putstr("  esac\n");
   putstr("}\n");
 #endif

--- a/sh-runtime.c
+++ b/sh-runtime.c
@@ -279,7 +279,7 @@ DEFINE_RUNTIME_FUN(char_to_int)
 
   putstr("char_to_int() {\n");
   putstr("  case $1 in\n");
-  putstr("    [a-zA-Z0-9]) __c=$((__c2i_$1)) ;;\n");
+  putstr("    [[:alnum:]]) __c=$((__c2i_$1)) ;;\n");
 #else
   putstr("char_to_int() {\n");
   putstr("  case $1 in\n");

--- a/sh.c
+++ b/sh.c
@@ -2381,7 +2381,8 @@ void comp_glo_decl(ast node) {
 
 void prologue() {
   putstr("#!/bin/sh\n");
-  putstr("set -e -u\n\n");
+  putstr("set -e -u\n");
+  putstr("LC_ALL=C\n\n");
 }
 
 void epilogue() {

--- a/tests/_all/input-output/read-unicode.c
+++ b/tests/_all/input-output/read-unicode.c
@@ -1,0 +1,30 @@
+// Make sure we can read unicode characters. This is to make sure the utilities
+// we compile using pnut-sh can process all kind of files.
+// This test is not essential for the bootstrap but being able to properly read
+// non-ascii characters makes pnut more general.
+//
+// Yash's IO is a little bit weird and it's not a very popular shell, disabling the test for now.
+// expect_failure_for: yash
+
+#ifndef PNUT_CC
+#include <stdio.h>
+#else
+typedef int FILE;
+#endif
+
+void putstr(const char *s) {
+  while (*s) {
+    putchar(*s);
+    s++;
+  }
+}
+
+void main() {
+  int i = 0;
+  char c;
+  FILE *f = fopen("tests/_all/input-output/unicode.txt", "r");
+  putstr("printf? 💣\n");
+  while ((c = fgetc(f)) != -1) {
+    putchar(c);
+  }
+}

--- a/tests/_all/input-output/read-unicode.golden
+++ b/tests/_all/input-output/read-unicode.golden
@@ -1,0 +1,3 @@
+printf? 💣
+accents: éôèà
+some emoji: 🥜

--- a/tests/_all/input-output/unicode.txt
+++ b/tests/_all/input-output/unicode.txt
@@ -1,0 +1,2 @@
+accents: éôèà
+some emoji: 🥜


### PR DESCRIPTION
## Context

I tried to compile [examples/repl.c](https://github.com/udem-dlteam/pnut/blob/master/examples/repl.c) with the `bootstrap-results/pnut.sh` and it failed with `line 6774: __c2i_é: parameter not set`. This is because the `[a-zA-Z0-9]` pattern can include non-ASCII characters depending on the locale.

This change also has the nice side effect of speeding up ksh by 12% taking 28s instead of 32s on my machine. Other shells show no significant improvement when bootstrapping and in the compile-times benchmarks.
