### PR TITLE
Don't generate printf calls starting with '-'

### DIFF
--- a/tests/_sh/input-output/printf.c
+++ b/tests/_sh/input-output/printf.c
@@ -1,0 +1,18 @@
+#ifndef PNUT_CC
+#include <stdio.h>
+#else
+typedef int FILE;
+#endif
+
+void main() {
+  int i = 0;
+  char c;
+  // Test %d, %c, %x, %s, %.*s, %4s
+  printf("Hello, world!\n");
+  printf("%d\n", 42);
+  printf("%c\n", 'a');
+  printf("Hello %c-%xPO\n", 'C', 3);
+  printf("Hello, %s!\n", "world");
+  printf("Hello, world! %.*s\n", 5, "R2-D2 (beep-boop)");
+  printf("Hello, world! <%12.5s>\n", "ROBOT");
+}

--- a/tests/_sh/input-output/printf.golden
+++ b/tests/_sh/input-output/printf.golden
@@ -1,0 +1,7 @@
+Hello, world!
+42
+a
+Hello C-3PO
+Hello, world!
+Hello, world! R2-D2
+Hello, world! <       ROBOT>


### PR DESCRIPTION
## Context

This fixes [an annoying bug](https://github.com/udem-dlteam/pnut/issues/50) where `printf` calls with format specifiers separated with `-` would fail on certain shells because the dash would be interpreted as a flag.

This PR adds a shell test for `printf` because the `printf` function wasn't covered by the tests (other than the bootstrap).