### PR TITLE
Add CI check for certain pnut-sh options

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Diff examples
         run: |
-          files=$(git diff --name-only)
+          git add examples/
+          files=$(git diff HEAD --name-only)
           if [ -n "$files" ]; then
             echo "Examples are out of date. Please run ./examples/prepare.sh"
             echo "The following files are out of date:"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,9 @@ jobs:
     strategy:
       matrix:
         shell: ["bash", "dash", "ksh", "mksh", "yash", "zsh"]
+        include:
+          - shell: dash # Using dash because it's the fastest
+            pnut_opts: "'-DSH_SAVE_VARS_WITH_SET' '-DOPTIMIZE_CONSTANT_PARAM'"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -79,6 +82,10 @@ jobs:
         run: |
           set -e
           ./run-tests.sh sh --shell ${{ matrix.shell }}
+          for pnut_opts in ${{ matrix.pnut_opts }}; do
+            echo "Running tests with pnut options: $pnut_opts"
+            PNUT_OPTIONS="${pnut_opts}" ./run-tests.sh sh --shell ${{ matrix.shell }}
+          done
 
   bootstrap-pnut-sh:
     strategy:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@
 
 trap "exit 1" INT
 
-fail() { echo "$1"; exit $2; }
+fail() { echo "❌ $1"; exit 1; }
 
 if [ $# -lt 1 ]; then
   fail "Usage: $0 <backend> --shell shell -m pattern --bootstrap" 1
@@ -271,5 +271,6 @@ run_tests() {
   fi
 }
 
+compile_pnut # Precompile pnut to get an error message if it fails
 find tests -name "*.exe" -exec rm {} \; # Clear cached pnut executables
 run_tests "$pattern"


### PR DESCRIPTION
## Context

The code gated by the `OPTIMIZE_CONSTANT_PARAM` option needs to be kept in sync with the rest of the shell code generator to handle all statements or else the compiler crashes. Because it's disabled by default it's easy to forget to update it when handling new kinds of AST nodes. That has happened a few times before (https://github.com/udem-dlteam/pnut/pull/46/commits/564a2abe4f3ea54bbff114ba11dcfc6ae29dd32c and https://github.com/udem-dlteam/pnut/pull/25/commits/a49f91f234aba50569e2c0b4202d50ab68c1b98b)  and [just happened](https://github.com/udem-dlteam/pnut/pull/84#pullrequestreview-2303482783) so let's add a CI check so we don't need to remember.

This last PR also revealed a bug in the examples-up-to-date CI check where missing compiled files didn't trigger the `files are out of date` error.