### PR TITLE
Use --no-cache in make-artifact.sh

### DIFF
--- a/make-artifact.sh
+++ b/make-artifact.sh
@@ -24,7 +24,8 @@ pandoc artifact.md -o "$ZIP_DIR/artifact.pdf"
 docker build . \
   -t "$DOCKER_IMAGE_TAG" \
   --build-arg PNUT_SOURCE=clone \
-  --platform linux/amd64
+  --platform linux/amd64 \
+  --no-cache
 
 # Export it
 docker save "$DOCKER_IMAGE_TAG" | gzip > "$ZIP_DIR/$DOCKER_IMAGE_TAG-image.tar.gz"


### PR DESCRIPTION
## Context

When running `make-artifact.sh`, the pnut directory that's placed in the docker image is not refreshed because the layer is cached. We want to force a refresh using the `--no-cache` option when building the image.