### PR TITLE
Don't generate trailing whitespace for function calls with no arguments

### DIFF
--- a/examples/compiled/base64.sh
+++ b/examples/compiled/base64.sh
@@ -75,11 +75,11 @@ _codes=$__str_0
 _encode() {
   let b1; let b2; let b3
   while [ 1 != 0 ] ; do
-    _getchar b1 
+    _getchar b1
     if [ $b1 -lt 0 ] ; then
       break
     fi
-    _getchar b2 
+    _getchar b2
     printf \\$(((_$((_codes + (b1 >> 2))))/64))$(((_$((_codes + (b1 >> 2))))/8%8))$(((_$((_codes + (b1 >> 2))))%8))
     if [ $b2 -lt 0 ] ; then
       printf \\$(((_$((_codes + (63 & (b1 << 4)))))/64))$(((_$((_codes + (63 & (b1 << 4)))))/8%8))$(((_$((_codes + (63 & (b1 << 4)))))%8))
@@ -88,7 +88,7 @@ _encode() {
       break
     else
       printf \\$(((_$((_codes + (63 & ((b1 << 4) | (b2 >> 4))))))/64))$(((_$((_codes + (63 & ((b1 << 4) | (b2 >> 4))))))/8%8))$(((_$((_codes + (63 & ((b1 << 4) | (b2 >> 4))))))%8))
-      _getchar b3 
+      _getchar b3
       if [ $b3 -lt 0 ] ; then
         printf \\$(((_$((_codes + (63 & (b2 << 2)))))/64))$(((_$((_codes + (63 & (b2 << 2)))))/8%8))$(((_$((_codes + (63 & (b2 << 2)))))%8))
         printf \\$(((__EQ__)/64))$(((__EQ__)/8%8))$(((__EQ__)%8))
@@ -107,7 +107,7 @@ defarr _lut 256
 : $((__t1 = c = 0))
 _get() {
   let c; let __t1
-  while _getchar __t1 ; [ $((c = __t1)) -ge 0 ] ; do
+  while _getchar __t1; [ $((c = __t1)) -ge 0 ] ; do
     if [ $((c = _$((_lut + c)))) -ge 0 ] ; then
       break
     fi
@@ -129,16 +129,16 @@ _decode() {
     : $((_$((_lut + 255 & _$((_codes + i)))) = i))
     : $((i += 1))
   done
-  while _get __t1 ; [ $((c1 = __t1)) -ge 0 ] ; do
-    if _get __t1 ; [ $((c2 = __t1)) -lt 0 ] ; then
+  while _get __t1; [ $((c1 = __t1)) -ge 0 ] ; do
+    if _get __t1; [ $((c2 = __t1)) -lt 0 ] ; then
       exit 1
     fi
     printf \\$((((c1 << 2) | (c2 >> 4))/64))$((((c1 << 2) | (c2 >> 4))/8%8))$((((c1 << 2) | (c2 >> 4))%8))
-    if _get __t1 ; [ $((c3 = __t1)) -lt 0 ] ; then
+    if _get __t1; [ $((c3 = __t1)) -lt 0 ] ; then
       break
     fi
     printf \\$(((255 & ((c2 << 4) | (c3 >> 2)))/64))$(((255 & ((c2 << 4) | (c3 >> 2)))/8%8))$(((255 & ((c2 << 4) | (c3 >> 2)))%8))
-    if _get __t1 ; [ $((c4 = __t1)) -lt 0 ] ; then
+    if _get __t1; [ $((c4 = __t1)) -lt 0 ] ; then
       break
     fi
     printf \\$(((255 & ((c3 << 6) | c4))/64))$(((255 & ((c3 << 6) | c4))/8%8))$(((255 & ((c3 << 6) | c4))%8))
@@ -149,9 +149,9 @@ _decode() {
 : $((myargv = argc = 0))
 _main() { let argc $2; let myargv $3
   if [ $argc = 1 ] ; then
-    _encode __ 
+    _encode __
   elif [ $argc = 2 ] && [ $((_$((_$((myargv + 1)) + 0)))) = $__MINUS__ ] && [ $((_$((_$((myargv + 1)) + 1)))) = $__d__ ] && [ $((_$((_$((myargv + 1)) + 2)))) = $__NUL__ ] ; then
-    _decode __ 
+    _decode __
   else
     exit 1
   fi

--- a/examples/compiled/c4.sh
+++ b/examples/compiled/c4.sh
@@ -155,7 +155,7 @@ _next() {
           if [ $((_$_le)) -le $_ADJ ] ; then
             printf " %d\n" $((_$((_le += 1))))
           else
-            printf "\n" 
+            printf "\n"
           fi
         done
       fi
@@ -328,38 +328,38 @@ _expr() { # lev: $2
   elif [ $_tk = $_Num ] ; then
     : $((_$((_e += 1)) = _IMM))
     : $((_$((_e += 1)) = _ival))
-    _next __ 
+    _next __
     _ty=$_INT
   elif [ $_tk = $__DQUOTE__ ] ; then
     : $((_$((_e += 1)) = _IMM))
     : $((_$((_e += 1)) = _ival))
-    _next __ 
+    _next __
     while [ $_tk = $__DQUOTE__ ] ; do
-      _next __ 
+      _next __
     done
     _data=$(((_data + 1) & -(1)))
     _ty=$_PTR
   elif [ $_tk = $_Sizeof ] ; then
-    _next __ 
+    _next __
     if [ $_tk = $__LPAREN__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: open paren expected in sizeof\n" $_line
       exit -1
     fi
     _ty=$_INT
     if [ $_tk = $_Int ] ; then
-      _next __ 
+      _next __
     elif [ $_tk = $_Char ] ; then
-      _next __ 
+      _next __
       _ty=$_CHAR
     fi
     while [ $_tk = $_Mul ] ; do
-      _next __ 
+      _next __
       _ty=$((_ty + _PTR))
     done
     if [ $_tk = $__RPAREN__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: close paren expected in sizeof\n" $_line
       exit -1
@@ -369,19 +369,19 @@ _expr() { # lev: $2
     _ty=$_INT
   elif [ $_tk = $_Id ] ; then
     d=$_id
-    _next __ 
+    _next __
     if [ $_tk = $__LPAREN__ ] ; then
-      _next __ 
+      _next __
       t=0
       while [ $_tk != $__RPAREN__ ] ; do
         _expr __ $_Assign
         : $((_$((_e += 1)) = _PSH))
         : $((t += 1))
         if [ $_tk = $__COMMA__ ] ; then
-          _next __ 
+          _next __
         fi
       done
-      _next __ 
+      _next __
       if [ $((_$((d + _Class)))) = $_Sys ] ; then
         : $((_$((_e += 1)) = _$((d + _Val))))
       elif [ $((_$((d + _Class)))) = $_Fun ] ; then
@@ -414,16 +414,16 @@ _expr() { # lev: $2
       : $((_$((_e += 1)) = ((_ty = _$((d + _Type))) == _CHAR) ? _LC: _LI))
     fi
   elif [ $_tk = $__LPAREN__ ] ; then
-    _next __ 
+    _next __
     if [ $_tk = $_Int ] || [ $_tk = $_Char ] ; then
       t=$(((_tk == _Int) ? _INT: _CHAR))
-      _next __ 
+      _next __
       while [ $_tk = $_Mul ] ; do
-        _next __ 
+        _next __
         t=$((t + _PTR))
       done
       if [ $_tk = $__RPAREN__ ] ; then
-        _next __ 
+        _next __
       else
         printf "%d: bad cast\n" $_line
         exit -1
@@ -433,14 +433,14 @@ _expr() { # lev: $2
     else
       _expr __ $_Assign
       if [ $_tk = $__RPAREN__ ] ; then
-        _next __ 
+        _next __
       else
         printf "%d: close paren expected\n" $_line
         exit -1
       fi
     fi
   elif [ $_tk = $_Mul ] ; then
-    _next __ 
+    _next __
     _expr __ $_Inc
     if [ $_ty -gt $_INT ] ; then
       _ty=$((_ty - _PTR))
@@ -450,7 +450,7 @@ _expr() { # lev: $2
     fi
     : $((_$((_e += 1)) = (_ty == _CHAR) ? _LC: _LI))
   elif [ $_tk = $_And ] ; then
-    _next __ 
+    _next __
     _expr __ $_Inc
     if [ $((_$_e)) = $_LC ] || [ $((_$_e)) = $_LI ] ; then
       : $((_e -= 1))
@@ -460,7 +460,7 @@ _expr() { # lev: $2
     fi
     _ty=$((_ty + _PTR))
   elif [ $_tk = $__EXCL__ ] ; then
-    _next __ 
+    _next __
     _expr __ $_Inc
     : $((_$((_e += 1)) = _PSH))
     : $((_$((_e += 1)) = _IMM))
@@ -468,7 +468,7 @@ _expr() { # lev: $2
     : $((_$((_e += 1)) = _EQ))
     _ty=$_INT
   elif [ $_tk = $__TILDE__ ] ; then
-    _next __ 
+    _next __
     _expr __ $_Inc
     : $((_$((_e += 1)) = _PSH))
     : $((_$((_e += 1)) = _IMM))
@@ -476,15 +476,15 @@ _expr() { # lev: $2
     : $((_$((_e += 1)) = _XOR))
     _ty=$_INT
   elif [ $_tk = $_Add ] ; then
-    _next __ 
+    _next __
     _expr __ $_Inc
     _ty=$_INT
   elif [ $_tk = $_Sub ] ; then
-    _next __ 
+    _next __
     : $((_$((_e += 1)) = _IMM))
     if [ $_tk = $_Num ] ; then
       : $((_$((_e += 1)) = -(_ival)))
-      _next __ 
+      _next __
     else
       : $((_$((_e += 1)) = -1))
       : $((_$((_e += 1)) = _PSH))
@@ -494,7 +494,7 @@ _expr() { # lev: $2
     _ty=$_INT
   elif [ $_tk = $_Inc ] || [ $_tk = $_Dec ] ; then
     t=$_tk
-    _next __ 
+    _next __
     _expr __ $_Inc
     if [ $((_$_e)) = $_LC ] ; then
       : $((_$_e = _PSH))
@@ -518,7 +518,7 @@ _expr() { # lev: $2
   while [ $_tk -ge $lev ] ; do
     t=$_ty
     if [ $_tk = $_Assign ] ; then
-      _next __ 
+      _next __
       if [ $((_$_e)) = $_LC ] || [ $((_$_e)) = $_LI ] ; then
         : $((_$_e = _PSH))
       else
@@ -528,12 +528,12 @@ _expr() { # lev: $2
       _expr __ $_Assign
       : $((_$((_e += 1)) = ((_ty = t) == _CHAR) ? _SC: _SI))
     elif [ $_tk = $_Cond ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _BZ))
       d=$((_e += 1))
       _expr __ $_Assign
       if [ $_tk = $__COLON__ ] ; then
-        _next __ 
+        _next __
       else
         printf "%d: conditional missing colon\n" $_line
         exit -1
@@ -544,87 +544,87 @@ _expr() { # lev: $2
       _expr __ $_Cond
       : $((_$d = (_e + 1)))
     elif [ $_tk = $_Lor ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _BNZ))
       d=$((_e += 1))
       _expr __ $_Lan
       : $((_$d = (_e + 1)))
       _ty=$_INT
     elif [ $_tk = $_Lan ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _BZ))
       d=$((_e += 1))
       _expr __ $_Or
       : $((_$d = (_e + 1)))
       _ty=$_INT
     elif [ $_tk = $_Or ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Xor
       : $((_$((_e += 1)) = _OR))
       _ty=$_INT
     elif [ $_tk = $_Xor ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_And
       : $((_$((_e += 1)) = _XOR))
       _ty=$_INT
     elif [ $_tk = $_And ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Eq
       : $((_$((_e += 1)) = _AND))
       _ty=$_INT
     elif [ $_tk = $_Eq ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Lt
       : $((_$((_e += 1)) = _EQ))
       _ty=$_INT
     elif [ $_tk = $_Ne ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Lt
       : $((_$((_e += 1)) = _NE))
       _ty=$_INT
     elif [ $_tk = $_Lt ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Shl
       : $((_$((_e += 1)) = _LT))
       _ty=$_INT
     elif [ $_tk = $_Gt ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Shl
       : $((_$((_e += 1)) = _GT))
       _ty=$_INT
     elif [ $_tk = $_Le ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Shl
       : $((_$((_e += 1)) = _LE))
       _ty=$_INT
     elif [ $_tk = $_Ge ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Shl
       : $((_$((_e += 1)) = _GE))
       _ty=$_INT
     elif [ $_tk = $_Shl ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Add
       : $((_$((_e += 1)) = _SHL))
       _ty=$_INT
     elif [ $_tk = $_Shr ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Add
       : $((_$((_e += 1)) = _SHR))
       _ty=$_INT
     elif [ $_tk = $_Add ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Mul
       if [ $((_ty = t)) -gt $_PTR ] ; then
@@ -635,7 +635,7 @@ _expr() { # lev: $2
       fi
       : $((_$((_e += 1)) = _ADD))
     elif [ $_tk = $_Sub ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Mul
       if [ $t -gt $_PTR ] && [ $t = $_ty ] ; then
@@ -655,19 +655,19 @@ _expr() { # lev: $2
         : $((_$((_e += 1)) = _SUB))
       fi
     elif [ $_tk = $_Mul ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Inc
       : $((_$((_e += 1)) = _MUL))
       _ty=$_INT
     elif [ $_tk = $_Div ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Inc
       : $((_$((_e += 1)) = _DIV))
       _ty=$_INT
     elif [ $_tk = $_Mod ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Inc
       : $((_$((_e += 1)) = _MOD))
@@ -692,13 +692,13 @@ _expr() { # lev: $2
       : $((_$((_e += 1)) = _IMM))
       : $((_$((_e += 1)) = (_ty > _PTR) ? 1: 1))
       : $((_$((_e += 1)) = (_tk == _Inc) ? _SUB: _ADD))
-      _next __ 
+      _next __
     elif [ $_tk = $_Brak ] ; then
-      _next __ 
+      _next __
       : $((_$((_e += 1)) = _PSH))
       _expr __ $_Assign
       if [ $_tk = $__RBRACK__ ] ; then
-        _next __ 
+        _next __
       else
         printf "%d: close bracket expected\n" $_line
         exit -1
@@ -726,77 +726,77 @@ _expr() { # lev: $2
 _stmt() {
   set $@ $a $b
   if [ $_tk = $_If ] ; then
-    _next __ 
+    _next __
     if [ $_tk = $__LPAREN__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: open paren expected\n" $_line
       exit -1
     fi
     _expr __ $_Assign
     if [ $_tk = $__RPAREN__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: close paren expected\n" $_line
       exit -1
     fi
     : $((_$((_e += 1)) = _BZ))
     b=$((_e += 1))
-    _stmt __ 
+    _stmt __
     if [ $_tk = $_Else ] ; then
       : $((_$b = (_e + 3)))
       : $((_$((_e += 1)) = _JMP))
       b=$((_e += 1))
-      _next __ 
-      _stmt __ 
+      _next __
+      _stmt __
     fi
     : $((_$b = (_e + 1)))
   elif [ $_tk = $_While ] ; then
-    _next __ 
+    _next __
     a=$((_e + 1))
     if [ $_tk = $__LPAREN__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: open paren expected\n" $_line
       exit -1
     fi
     _expr __ $_Assign
     if [ $_tk = $__RPAREN__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: close paren expected\n" $_line
       exit -1
     fi
     : $((_$((_e += 1)) = _BZ))
     b=$((_e += 1))
-    _stmt __ 
+    _stmt __
     : $((_$((_e += 1)) = _JMP))
     : $((_$((_e += 1)) = a))
     : $((_$b = (_e + 1)))
   elif [ $_tk = $_Return ] ; then
-    _next __ 
+    _next __
     if [ $_tk != $__SEMICOLON__ ] ; then
       _expr __ $_Assign
     fi
     : $((_$((_e += 1)) = _LEV))
     if [ $_tk = $__SEMICOLON__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: semicolon expected\n" $_line
       exit -1
     fi
   elif [ $_tk = $__LBRACE__ ] ; then
-    _next __ 
+    _next __
     while [ $_tk != $__RBRACE__ ] ; do
-      _stmt __ 
+      _stmt __
     done
-    _next __ 
+    _next __
   elif [ $_tk = $__SEMICOLON__ ] ; then
-    _next __ 
+    _next __
   else
     _expr __ $_Assign
     if [ $_tk = $__SEMICOLON__ ] ; then
-      _next __ 
+      _next __
     else
       printf "%d: semicolon expected\n" $_line
       exit -1
@@ -823,15 +823,15 @@ _main() { # argc: $2, argv: $3
     : $((argv_ += 1))
   fi
   if [ $argc -lt 1 ] ; then
-    printf "usage: c4 [-s] [-d] file ...\n" 
+    printf "usage: c4 [-s] [-d] file ...\n"
     : $(($1 = -1))
     : $((__tmp = $1)) $((argc = $4)) $((argv_ = $5)) $((fd = $6)) $((bt = $7)) $((ty = $8)) $((poolsz = $9)) $((idmain = ${10})) $((pc = ${11})) $((sp = ${12})) $((bp = ${13})) $((a = ${14})) $((cycle = ${15})) $((i = ${16})) $((t = ${17})) $((__t1 = ${18})) $(($1 = __tmp))
     return
   fi
   if _open __t1 $((_$argv_)) 0; [ $((fd = __t1)) -lt 0 ] ; then
-    printf "could not open(" 
+    printf "could not open("
     _put_pstr __ $((_$argv_))
-    printf ")\n" 
+    printf ")\n"
     : $(($1 = -1))
     : $((__tmp = $1)) $((argc = $4)) $((argv_ = $5)) $((fd = $6)) $((bt = $7)) $((ty = $8)) $((poolsz = $9)) $((idmain = ${10})) $((pc = ${11})) $((sp = ${12})) $((bp = ${13})) $((a = ${14})) $((cycle = ${15})) $((i = ${16})) $((t = ${17})) $((__t1 = ${18})) $(($1 = __tmp))
     return
@@ -865,19 +865,19 @@ _main() { # argc: $2, argv: $3
   _p=$__str_1
   i=$_Char
   while [ $i -le $_While ] ; do
-    _next __ 
+    _next __
     : $((_$((_id + _Tk)) = (i += 1) - 1))
   done
   i=$_OPEN
   while [ $i -le $_EXIT ] ; do
-    _next __ 
+    _next __
     : $((_$((_id + _Class)) = _Sys))
     : $((_$((_id + _Type)) = _INT))
     : $((_$((_id + _Val)) = (i += 1) - 1))
   done
-  _next __ 
+  _next __
   : $((_$((_id + _Tk)) = _Char))
-  _next __ 
+  _next __
   idmain=$_id
   if _malloc __t1 $poolsz; [ $((!(_lp = _p = __t1))) != 0 ] ; then
     printf "could not malloc(%d) source area\n" $poolsz
@@ -894,21 +894,21 @@ _main() { # argc: $2, argv: $3
   : $((_$((_p + i)) = 0))
   _close __ $fd
   _line=1
-  _next __ 
+  _next __
   while [ $_tk != 0 ] ; do
     bt=$_INT
     if [ $_tk = $_Int ] ; then
-      _next __ 
+      _next __
     elif [ $_tk = $_Char ] ; then
-      _next __ 
+      _next __
       bt=$_CHAR
     elif [ $_tk = $_Enum ] ; then
-      _next __ 
+      _next __
       if [ $_tk != $__LBRACE__ ] ; then
-        _next __ 
+        _next __
       fi
       if [ $_tk = $__LBRACE__ ] ; then
-        _next __ 
+        _next __
         i=0
         while [ $_tk != $__RBRACE__ ] ; do
           if [ $_tk != $_Id ] ; then
@@ -917,9 +917,9 @@ _main() { # argc: $2, argv: $3
             : $((__tmp = $1)) $((argc = $4)) $((argv_ = $5)) $((fd = $6)) $((bt = $7)) $((ty = $8)) $((poolsz = $9)) $((idmain = ${10})) $((pc = ${11})) $((sp = ${12})) $((bp = ${13})) $((a = ${14})) $((cycle = ${15})) $((i = ${16})) $((t = ${17})) $((__t1 = ${18})) $(($1 = __tmp))
             return
           fi
-          _next __ 
+          _next __
           if [ $_tk = $_Assign ] ; then
-            _next __ 
+            _next __
             if [ $_tk != $_Num ] ; then
               printf "%d: bad enum initializer\n" $_line
               : $(($1 = -1))
@@ -927,22 +927,22 @@ _main() { # argc: $2, argv: $3
               return
             fi
             i=$_ival
-            _next __ 
+            _next __
           fi
           : $((_$((_id + _Class)) = _Num))
           : $((_$((_id + _Type)) = _INT))
           : $((_$((_id + _Val)) = (i += 1) - 1))
           if [ $_tk = $__COMMA__ ] ; then
-            _next __ 
+            _next __
           fi
         done
-        _next __ 
+        _next __
       fi
     fi
     while [ $_tk != $__SEMICOLON__ ] && [ $_tk != $__RBRACE__ ] ; do
       ty=$bt
       while [ $_tk = $_Mul ] ; do
-        _next __ 
+        _next __
         ty=$((ty + _PTR))
       done
       if [ $_tk != $_Id ] ; then
@@ -957,23 +957,23 @@ _main() { # argc: $2, argv: $3
         : $((__tmp = $1)) $((argc = $4)) $((argv_ = $5)) $((fd = $6)) $((bt = $7)) $((ty = $8)) $((poolsz = $9)) $((idmain = ${10})) $((pc = ${11})) $((sp = ${12})) $((bp = ${13})) $((a = ${14})) $((cycle = ${15})) $((i = ${16})) $((t = ${17})) $((__t1 = ${18})) $(($1 = __tmp))
         return
       fi
-      _next __ 
+      _next __
       : $((_$((_id + _Type)) = ty))
       if [ $_tk = $__LPAREN__ ] ; then
         : $((_$((_id + _Class)) = _Fun))
         : $((_$((_id + _Val)) = (_e + 1)))
-        _next __ 
+        _next __
         i=0
         while [ $_tk != $__RPAREN__ ] ; do
           ty=$_INT
           if [ $_tk = $_Int ] ; then
-            _next __ 
+            _next __
           elif [ $_tk = $_Char ] ; then
-            _next __ 
+            _next __
             ty=$_CHAR
           fi
           while [ $_tk = $_Mul ] ; do
-            _next __ 
+            _next __
             ty=$((ty + _PTR))
           done
           if [ $_tk != $_Id ] ; then
@@ -994,12 +994,12 @@ _main() { # argc: $2, argv: $3
           : $((_$((_id + _Type)) = ty))
           : $((_$((_id + _HVal)) = _$((_id + _Val))))
           : $((_$((_id + _Val)) = (i += 1) - 1))
-          _next __ 
+          _next __
           if [ $_tk = $__COMMA__ ] ; then
-            _next __ 
+            _next __
           fi
         done
-        _next __ 
+        _next __
         if [ $_tk != $__LBRACE__ ] ; then
           printf "%d: bad function definition\n" $_line
           : $(($1 = -1))
@@ -1007,14 +1007,14 @@ _main() { # argc: $2, argv: $3
           return
         fi
         _loc=$((i += 1))
-        _next __ 
+        _next __
         while [ $_tk = $_Int ] || [ $_tk = $_Char ] ; do
           bt=$(((_tk == _Int) ? _INT: _CHAR))
-          _next __ 
+          _next __
           while [ $_tk != $__SEMICOLON__ ] ; do
             ty=$bt
             while [ $_tk = $_Mul ] ; do
-              _next __ 
+              _next __
               ty=$((ty + _PTR))
             done
             if [ $_tk != $_Id ] ; then
@@ -1035,17 +1035,17 @@ _main() { # argc: $2, argv: $3
             : $((_$((_id + _Type)) = ty))
             : $((_$((_id + _HVal)) = _$((_id + _Val))))
             : $((_$((_id + _Val)) = i += 1))
-            _next __ 
+            _next __
             if [ $_tk = $__COMMA__ ] ; then
-              _next __ 
+              _next __
             fi
           done
-          _next __ 
+          _next __
         done
         : $((_$((_e += 1)) = _ENT))
         : $((_$((_e += 1)) = i - _loc))
         while [ $_tk != $__RBRACE__ ] ; do
-          _stmt __ 
+          _stmt __
         done
         : $((_$((_e += 1)) = _LEV))
         _id=$_sym
@@ -1063,13 +1063,13 @@ _main() { # argc: $2, argv: $3
         _data=$((_data + 1))
       fi
       if [ $_tk = $__COMMA__ ] ; then
-        _next __ 
+        _next __
       fi
     done
-    _next __ 
+    _next __
   done
   if [ $((!(pc = _$((idmain + _Val))))) != 0 ] ; then
-    printf "main() not defined\n" 
+    printf "main() not defined\n"
     : $(($1 = -1))
     : $((__tmp = $1)) $((argc = $4)) $((argv_ = $5)) $((fd = $6)) $((bt = $7)) $((ty = $8)) $((poolsz = $9)) $((idmain = ${10})) $((pc = ${11})) $((sp = ${12})) $((bp = ${13})) $((a = ${14})) $((cycle = ${15})) $((i = ${16})) $((t = ${17})) $((__t1 = ${18})) $(($1 = __tmp))
     return
@@ -1096,7 +1096,7 @@ _main() { # argc: $2, argv: $3
       if [ $i -le $_ADJ ] ; then
         printf " %d\n" $((_$pc))
       else
-        printf "\n" 
+        printf "\n"
       fi
     fi
     if [ $i = $_LEA ] ; then

--- a/examples/compiled/cp.sh
+++ b/examples/compiled/cp.sh
@@ -4,9 +4,9 @@ LC_ALL=C
 
 : $((filename = 0))
 _file_error() { let filename $2
-  printf "cp: " 
+  printf "cp: "
   _put_pstr __ $filename
-  printf ": no such file or directory\n" 
+  printf ": no such file or directory\n"
   exit 1
   endlet $1 filename
 }
@@ -26,7 +26,7 @@ defarr _buffer 1024
 _main() { let argc $2; let args $3
   let src; let dst; let c; let len; let __t1
   if [ $argc != 3 ] ; then
-    printf "Usage: cp <source> <destination>\n" 
+    printf "Usage: cp <source> <destination>\n"
     : $(($1 = 1))
     endlet $1 __t1 len c dst src args argc
     return

--- a/examples/compiled/echo.sh
+++ b/examples/compiled/echo.sh
@@ -8,10 +8,10 @@ _main() { let argc $2; let argv_ $3
   i=1
   while [ $i -lt $argc ] ; do
     _put_pstr __ $((_$((argv_ + i))))
-    printf " " 
+    printf " "
     : $((i += 1))
   done
-  printf "\n" 
+  printf "\n"
   endlet $1 i argv_ argc
 }
 

--- a/examples/compiled/hello.sh
+++ b/examples/compiled/hello.sh
@@ -3,7 +3,7 @@ set -e -u -f
 LC_ALL=C
 
 _main() {
-  printf "Hello, world\n" 
+  printf "Hello, world\n"
 }
 
 # Runtime library

--- a/examples/compiled/non_zero.sh
+++ b/examples/compiled/non_zero.sh
@@ -7,16 +7,16 @@ _main() {
   let n; let __t1
   n=0
   while :; do
-    printf "Enter a non-zero single-digit number:\r\n" 
-    _getchar n 
-    while _getchar __t1 ; [ $__NEWLINE__ != $__t1 ] ; do
+    printf "Enter a non-zero single-digit number:\r\n"
+    _getchar n
+    while _getchar __t1; [ $__NEWLINE__ != $__t1 ] ; do
       :
     done
     [ $n = $__0__ ] || [ $((!((n >= __0__) && (n <= __9__)))) != 0 ]|| break
   done
-  printf "You entered " 
+  printf "You entered "
   printf \\$((n/64))$((n/8%8))$((n%8))
-  printf ": bye bye!\r\n" 
+  printf ": bye bye!\r\n"
   endlet $1 __t1 n
 }
 

--- a/examples/compiled/print-reverse.sh
+++ b/examples/compiled/print-reverse.sh
@@ -27,7 +27,7 @@ _main() { let argc $2; let argv_ $3
   while [ $i -lt $argc ] ; do
     _reverse_str __ $((_$((argv_ + i))))
     _put_pstr __ $i
-    printf "\n" 
+    printf "\n"
     : $((i += 1))
   done
   endlet $1 i argv_ argc

--- a/examples/compiled/repl.sh
+++ b/examples/compiled/repl.sh
@@ -300,7 +300,7 @@ _push2() { # car: $2, tag: $3
   : $((_$(((_alloc += 1) - 1)) = (0 << 1) | 1))
   _stack=$((_alloc - 4))
   if [ $_alloc = $_alloc_limit ] ; then
-    _gc __ 
+    _gc __
   fi
   : $((__tmp = $1)) $((car = $4)) $((tag = $5)) $(($1 = __tmp))
 }
@@ -416,7 +416,7 @@ _get_byte() {
 : $((__t1 = x = 0))
 _get_code() {
   set $@ $x $__t1
-  _get_byte __t1 
+  _get_byte __t1
   x=$((__t1 - 35))
   : $(($1 = (x < 0) ? 57: x))
   : $((__tmp = $1)) $((x = $2)) $((__t1 = $3)) $(($1 = __tmp))
@@ -426,7 +426,7 @@ _get_code() {
 _get_int() { # n: $2
   set $@ $n $x
   n=$2
-  _get_code x 
+  _get_code x
   : $((n *= (92 / 2)))
   if [ $x -lt $((92 / 2)) ] ; then
     : $(($1 = n + x))
@@ -468,7 +468,7 @@ _build_sym_table() {
   done
   accum=$((_$((_FALSE + __field1))))
   while [ 1 != 0 ] ; do
-    _get_byte c 
+    _get_byte c
     if [ $c = 44 ] ; then
       _create_sym __t1 $accum
       _symbol_table=$__t1
@@ -511,7 +511,7 @@ _init_weights() {
 _decode() {
   set $@ $n $d $op $x $c $__t1
   while [ 1 != 0 ] ; do
-    _get_code x 
+    _get_code x
     n=$x
     op=-1
     while [ $n -gt $((2 + (d = _$((_weights + (op += 1)))))) ] ; do
@@ -519,7 +519,7 @@ _decode() {
     done
     if [ $x -gt 90 ] ; then
       op=4
-      _pop n 
+      _pop n
     else
       if [ $((!op)) != 0 ] ; then
         _push2 __ $(((0 << 1) | 1)) $(((0 << 1) | 1))
@@ -542,7 +542,7 @@ _decode() {
         fi
       fi
       if [ $op -gt 4 ] ; then
-        _pop __t1 
+        _pop __t1
         _alloc_rib2 __t1 $n $(((0 << 1) | 1)) $__t1
         _alloc_rib __t1 $__t1 $((_$((_FALSE + __field1)))) $(((1 << 1) | 1))
         n=$__t1
@@ -603,19 +603,19 @@ _prim() { # no: $2
   if [ $no = 0 ] ; then
     _alloc_rib __t1 $(((0 << 1) | 1)) $(((0 << 1) | 1)) $(((0 << 1) | 1))
     new_rib=$__t1
-    _pop z 
-    _pop y 
-    _pop x 
+    _pop z
+    _pop y
+    _pop x
     : $((_$((new_rib + __field0)) = x))
     : $((_$((new_rib + __field1)) = y))
     : $((_$((new_rib + __field2)) = z))
     _push2 __ $new_rib $(((0 << 1) | 1))
   elif [ $no = 1 ] ; then
-    _pop x 
+    _pop x
     _close __ $((x >> 1))
   elif [ $no = 2 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     : $((_$((buffer + 0)) = (x >> 1)))
     _write success $((y >> 1)) $buffer 1
     if [ $success != 1 ] ; then
@@ -624,7 +624,7 @@ _prim() { # no: $2
     fi
     _push2 __ $((_$((_FALSE + __field0)))) $(((0 << 1) | 1))
   elif [ $no = 3 ] ; then
-    _pop x 
+    _pop x
     _read bytes_read $((x >> 1)) $buffer 1
     if [ $((!bytes_read)) != 0 ] ; then
       _push2 __ $((_$((_FALSE + __field1)))) $(((0 << 1) | 1))
@@ -632,7 +632,7 @@ _prim() { # no: $2
       _push2 __ $(((_$((buffer + 0)) << 1) | 1)) $(((0 << 1) | 1))
     fi
   elif [ $no = 4 ] ; then
-    _pop x 
+    _pop x
     _scm2str filename $x
     _open file $filename 1
     if [ $file -lt 0 ] ; then
@@ -642,7 +642,7 @@ _prim() { # no: $2
     fi
     _free __ $filename
   elif [ $no = 5 ] ; then
-    _pop x 
+    _pop x
     _scm2str filename $x
     _open file $filename 0
     if [ $file -lt 0 ] ; then
@@ -656,8 +656,8 @@ _prim() { # no: $2
   elif [ $no = 7 ] ; then
     _push2 __ $(((0 << 1) | 1)) $(((0 << 1) | 1))
   elif [ $no = 8 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     num_args=0
     : $((_$((_$((_FALSE + __field0)) + __field0)) = x))
     arg=$y
@@ -674,13 +674,13 @@ _prim() { # no: $2
     : $((__tmp = $1)) $((no = $3)) $((x = $4)) $((y = $5)) $((z = $6)) $((new_rib = $7)) $((arg = $8)) $((file = $9)) $((buffer = ${10})) $((success = ${11})) $((bytes_read = ${12})) $((num_args = ${13})) $((filename = ${14})) $((__t1 = ${15})) $(($1 = __tmp))
     return
   elif [ $no = 9 ] ; then
-    _pop x 
+    _pop x
     _push2 __ $x $(((0 << 1) | 1))
   elif [ $no = 10 ] ; then
-    _pop __ 
+    _pop __
   elif [ $no = 11 ] ; then
-    _pop x 
-    _pop __ 
+    _pop x
+    _pop __
     _push2 __ $x $(((0 << 1) | 1))
   elif [ $no = 12 ] ; then
     x=$((_$((_$((_stack + __field0)) + __field0))))
@@ -688,62 +688,62 @@ _prim() { # no: $2
     _alloc_rib __t1 $x $y $(((1 << 1) | 1))
     : $((_$((_stack + __field0)) = __t1))
   elif [ $no = 13 ] ; then
-    _pop x 
+    _pop x
     _bool2scm __t1 $((!(x & 1)))
     _push2 __ $__t1 $(((0 << 1) | 1))
   elif [ $no = 14 ] ; then
-    _pop x 
+    _pop x
     _push2 __ $((_$((x + __field0)))) $(((0 << 1) | 1))
   elif [ $no = 15 ] ; then
-    _pop x 
+    _pop x
     _push2 __ $((_$((x + __field1)))) $(((0 << 1) | 1))
   elif [ $no = 16 ] ; then
-    _pop x 
+    _pop x
     _push2 __ $((_$((x + __field2)))) $(((0 << 1) | 1))
   elif [ $no = 17 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _push2 __ $((_$((x + __field0)) = y)) $(((0 << 1) | 1))
   elif [ $no = 18 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _push2 __ $((_$((x + __field1)) = y)) $(((0 << 1) | 1))
   elif [ $no = 19 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _push2 __ $((_$((x + __field2)) = y)) $(((0 << 1) | 1))
   elif [ $no = 20 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _bool2scm __t1 $((x == y))
     _push2 __ $__t1 $(((0 << 1) | 1))
   elif [ $no = 21 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _bool2scm __t1 $(((x >> 1) < (y >> 1)))
     _push2 __ $__t1 $(((0 << 1) | 1))
   elif [ $no = 22 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _push2 __ $(((x + y) - 1)) $(((0 << 1) | 1))
   elif [ $no = 23 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _push2 __ $(((x - y) + 1)) $(((0 << 1) | 1))
   elif [ $no = 24 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     _push2 __ $(((((x >> 1) * (y >> 1)) << 1) | 1)) $(((0 << 1) | 1))
   elif [ $no = 25 ] ; then
-    _pop y 
-    _pop x 
+    _pop y
+    _pop x
     if [ $((y >> 1)) -lt 0 ] ; then
       _push2 __ $(((-(((x >> 1) / -((y >> 1)))) << 1) | 1)) $(((0 << 1) | 1))
     else
       _push2 __ $(((((x >> 1) / (y >> 1)) << 1) | 1)) $(((0 << 1) | 1))
     fi
   elif [ $no = 26 ] ; then
-    _pop x 
+    _pop x
     exit $((x >> 1))
   else
     exit 6
@@ -765,18 +765,18 @@ _run() {
       _get_opnd proc $((_$((_pc + __field1))))
       while [ 1 != 0 ] ; do
         if [ $((_$((proc + __field0)) & 1)) != 0 ] ; then
-          _pop __ 
+          _pop __
           _prim proc $((_$((proc + __field0)) >> 1))
           if [ $((!(proc & 1))) != 0 ] ; then
             continue
           fi
           if [ $jump != 0 ] ; then
-            _get_cont _pc 
+            _get_cont _pc
             : $((_$((_stack + __field1)) = _$((_pc + __field0))))
           fi
           _pc=$((_$((_pc + __field2))))
         else
-          _pop __t1 
+          _pop __t1
           nargs=$((__t1 >> 1))
           _alloc_rib __t1 $(((0 << 1) | 1)) $proc $(((0 << 1) | 1))
           s2=$__t1
@@ -786,7 +786,7 @@ _run() {
           nparams=$((nparams_vari >> 1))
           vari=$((nparams_vari & 1))
           if [ $((vari ? (nparams > nargs): (nparams != nargs))) != 0 ] ; then
-            printf "Unexpected number of arguments\n" 
+            printf "Unexpected number of arguments\n"
             exit 1
           fi
           : $((nargs -= nparams))
@@ -794,7 +794,7 @@ _run() {
             rest=$((_$((_FALSE + __field1))))
             i=0
             while [ $i -lt $nargs ] ; do
-              _pop __t1 
+              _pop __t1
               _alloc_rib __t1 $__t1 $rest $s2
               rest=$__t1
               s2=$((_$((rest + __field2))))
@@ -806,7 +806,7 @@ _run() {
           fi
           i=0
           while [ $i -lt $nparams ] ; do
-            _pop __t1 
+            _pop __t1
             _alloc_rib __t1 $__t1 $s2 $(((0 << 1) | 1))
             s2=$__t1
             : $((i += 1))
@@ -815,7 +815,7 @@ _run() {
           _list_tail __t1 $s2 $nparams
           c2=$__t1
           if [ $jump != 0 ] ; then
-            _get_cont k 
+            _get_cont k
             : $((_$((c2 + __field0)) = _$((k + __field0))))
             : $((_$((c2 + __field2)) = _$((k + __field2))))
           else
@@ -848,7 +848,7 @@ _run() {
       _push2 __ $((_$((_pc + __field1)))) $(((0 << 1) | 1))
       _pc=$((_$((_pc + __field2))))
     elif [ $instr = 4 ] ; then
-      _pop p 
+      _pop p
       if [ $p != $_FALSE ] ; then
         _pc=$((_$((_pc + __field1))))
       else
@@ -878,26 +878,26 @@ _setup_stack() {
 : $((__t2 = __t1 = 0))
 _init() {
   set $@ $__t1 $__t2
-  _init_weights __ 
-  _init_heap __ 
+  _init_weights __
+  _init_heap __
   _alloc_rib __t1 $(((0 << 1) | 1)) $(((0 << 1) | 1)) $(((5 << 1) | 1))
   _alloc_rib __t2 $(((0 << 1) | 1)) $(((0 << 1) | 1)) $(((5 << 1) | 1))
   _alloc_rib __t1 $__t1 $__t2 $(((5 << 1) | 1))
   _FALSE=$__t1
-  _build_sym_table __ 
-  _decode __ 
+  _build_sym_table __
+  _decode __
   _alloc_rib __t1 $(((0 << 1) | 1)) $_symbol_table $(((1 << 1) | 1))
   _set_global __ $__t1
   _set_global __ $_FALSE
   _set_global __ $((_$((_FALSE + __field0))))
   _set_global __ $((_$((_FALSE + __field1))))
-  _setup_stack __ 
-  _run __ 
+  _setup_stack __
+  _run __
   : $((__tmp = $1)) $((__t1 = $2)) $((__t2 = $3)) $(($1 = __tmp))
 }
 
 _main() {
-  _init __ 
+  _init __
 }
 
 # Character constants

--- a/examples/compiled/reverse.sh
+++ b/examples/compiled/reverse.sh
@@ -8,7 +8,7 @@ _main() { let argc $2; let argv_ $3
   i=1
   while [ $i -lt $argc ] ; do
     _put_pstr __ $((_$((argv_ + (argc - i)))))
-    printf " " 
+    printf " "
     : $((i += 1))
   done
   endlet $1 i argv_ argc

--- a/examples/compiled/select-file.sh
+++ b/examples/compiled/select-file.sh
@@ -175,7 +175,7 @@ _read_int() {
   let n; let c
   n=0
   while [ 1 != 0 ] ; do
-    _getchar c 
+    _getchar c
     if [ $c -ge $__0__ ] && [ $c -le $__9__ ] ; then
       n=$((((10 * n) + c) - __0__))
     else
@@ -189,20 +189,20 @@ _read_int() {
 : $((__t1 = len = ix = files = 0))
 _main() {
   let files; let ix; let len; let __t1
-  printf "Files in current directory (" 
-  _pwd __t1 
+  printf "Files in current directory ("
+  _pwd __t1
   _put_pstr __ $__t1
-  printf ")\n" 
-  _ls files 
+  printf ")\n"
+  _ls files
   _array_len len $files
   _print_array __ $files
   while [ 1 != 0 ] ; do
-    printf "Select a file to print: " 
-    _read_int ix 
+    printf "Select a file to print: "
+    _read_int ix
     if [ 0 -le $ix ] && [ $ix -lt $len ] ; then
       break
     fi
-    printf "Invalid index.\n" 
+    printf "Invalid index.\n"
   done
   _cat __ $((_$((files + ix))))
   endlet $1 __t1 len ix files

--- a/examples/compiled/sha256sum.sh
+++ b/examples/compiled/sha256sum.sh
@@ -161,8 +161,8 @@ _hex() { let byte $2
 _process_file() { let filename $2
   let i; let fd; let n; let h
   n=64
-  _sha256_setup __ 
-  _sha256_init __ 
+  _sha256_setup __
+  _sha256_init __
   _open fd $filename 0
   while [ $n = 64 ] ; do
     _read n $fd $_buf 64

--- a/examples/compiled/wc-stdin.sh
+++ b/examples/compiled/wc-stdin.sh
@@ -16,7 +16,7 @@ _main() {
   chars=0
   sep=0
   last_sep=0
-  while _getchar __t1 ; [ $((c = __t1)) != -1 ] ; do
+  while _getchar __t1; [ $((c = __t1)) != -1 ] ; do
     : $((chars += 1))
     if [ $c = $__NEWLINE__ ] ; then
       : $((lines += 1))

--- a/examples/compiled/welcome.sh
+++ b/examples/compiled/welcome.sh
@@ -7,14 +7,14 @@ _main() {
   let name; let i; let __t1
   _malloc name 100
   i=0
-  printf "What is your name?\n" 
-  while { _getchar __t1 ; [ $((_$((name + i)) = __t1)) != -1 ]; } && [ $((_$((name + i)))) != $__NEWLINE__ ] ; do
+  printf "What is your name?\n"
+  while { _getchar __t1; [ $((_$((name + i)) = __t1)) != -1 ]; } && [ $((_$((name + i)))) != $__NEWLINE__ ] ; do
     : $((i += 1))
   done
   : $((_$((name + i)) = __NUL__))
-  printf "Hello, " 
+  printf "Hello, "
   _put_pstr __ $name
-  printf "\n" 
+  printf "\n"
   endlet $1 __t1 i name
 }
 

--- a/sh.c
+++ b/sh.c
@@ -1523,10 +1523,10 @@ text printf_call(char *format_str, char *format_str_end, text params_text, bool 
     return 0;
   } else {
     // Some shells interpret leading - as options. In that case, we add -- in front of the format string.
-    return string_concat4(wrap_str_lit(format_str[0] == '-' ? "printf -- \"" : "printf \""),
+    return string_concat3(wrap_str_lit(format_str[0] == '-' ? "printf -- \"" : "printf \""),
                           escape_text(wrap_str_imm(format_str, format_str_end), escape),
-                          wrap_str_lit("\" "),
-                          params_text);
+                          concatenate_strings_with(wrap_char('\"'), params_text, wrap_char(' '))
+                          );
   }
 }
 
@@ -1715,12 +1715,10 @@ text comp_fun_call_code(ast node, ast assign_to) {
   else if (name_id == OPEN_ID)    { runtime_use_open = true; }
   else if (name_id == CLOSE_ID)   { runtime_use_close = true; }
 
-  return string_concat5(
+  return string_concat3(
     function_name(get_val(name)),
     wrap_char(' '),
-    comp_lvalue(assign_to),
-    wrap_char(' '),
-    fun_call_params(params)
+    concatenate_strings_with(comp_lvalue(assign_to), fun_call_params(params), wrap_char(' '))
   );
 }
 


### PR DESCRIPTION
## Context

It's annoying to see them and even more annoying when the editor trims them on save and it dirties files tracked with git.