### PR TITLE
Runtime: Use (__c = *__ptr) != 0 in loop condition

### DIFF
--- a/examples/compiled/c4.sh
+++ b/examples/compiled/c4.sh
@@ -1436,16 +1436,16 @@ _free() { # $2 = object to free
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }
 
 read_int() {
   __int=
-  while [ $((_$__fmt_ptr)) != 0 ] && [ $((_$__fmt_ptr)) -ge 48 ] && [ $((_$__fmt_ptr)) -le 57 ]; do
-    __int="$__int$((_$__fmt_ptr - 48))"
+  while [ $((__c = _$__fmt_ptr)) != 0 ] && [ $__c -ge 48 ] && [ $__c -le 57 ]; do
+    __int="$__int$((__c - 48))"
     : $((__fmt_ptr += 1))
   done
 }
@@ -1476,8 +1476,7 @@ _printf() { # $1 = printf format string, $2... = printf args
   __fmt_ptr=$1; shift
   __mod_start=0
   printf_reset
-  while [ "$((_$__fmt_ptr))" != 0 ] ; do
-    __head=$((_$__fmt_ptr))
+  while [ "$((__head = _$__fmt_ptr))" != 0 ] ; do
     __fmt_ptr=$((__fmt_ptr + 1))
     if [ $__mod -eq 1 ] ; then
       __char=$(printf "\\$(($__head/64))$(($__head/8%8))$(($__head%8))")

--- a/examples/compiled/cat.sh
+++ b/examples/compiled/cat.sh
@@ -139,8 +139,8 @@ read_byte() { # $2: fd
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/cp.sh
+++ b/examples/compiled/cp.sh
@@ -49,8 +49,8 @@ _main() { let argc $2; let args $3
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/echo.sh
+++ b/examples/compiled/echo.sh
@@ -19,8 +19,8 @@ _main() { let argc $2; let argv_ $3
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/print-reverse.sh
+++ b/examples/compiled/print-reverse.sh
@@ -37,8 +37,8 @@ _main() { let argc $2; let argv_ $3
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/repl.sh
+++ b/examples/compiled/repl.sh
@@ -1027,8 +1027,8 @@ read_byte() { # $2: fd
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/reverse.sh
+++ b/examples/compiled/reverse.sh
@@ -18,8 +18,8 @@ _main() { let argc $2; let argv_ $3
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/select-file.sh
+++ b/examples/compiled/select-file.sh
@@ -246,8 +246,8 @@ _getchar() {
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/sha256sum.sh
+++ b/examples/compiled/sha256sum.sh
@@ -361,8 +361,8 @@ read_byte() { # $2: fd
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/wc.sh
+++ b/examples/compiled/wc.sh
@@ -90,8 +90,8 @@ readonly __SPACE__=32
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/examples/compiled/welcome.sh
+++ b/examples/compiled/welcome.sh
@@ -64,8 +64,8 @@ _malloc() { # $2 = object size
 _put_pstr() {
   : $(($1 = 0)); shift # Return 0
   __addr=$1; shift
-  while [ $((_$__addr)) != 0 ]; do
-    printf \\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))
+  while [ $((__c = _$__addr)) != 0 ]; do
+    printf \\$((__c/64))$((__c/8%8))$((__c%8))
     : $((__addr += 1))
   done
 }

--- a/sh-runtime.c
+++ b/sh-runtime.c
@@ -539,11 +539,11 @@ DEPENDS_ON(putchar)
   putstr("_put_pstr() {\n");
   putstr("  : $(($1 = 0)); shift # Return 0\n");
   putstr("  __addr=$1; shift\n");
-  putstr("  while [ $((_$__addr)) != 0 ]; do\n");
+  putstr("  while [ $((__c = _$__addr)) != 0 ]; do\n");
 #ifdef RT_INLINE_PUTCHAR
-  putstr("    printf \\\\$((_$__addr/64))$((_$__addr/8%8))$((_$__addr%8))\n");
+  putstr("    printf \\\\$((__c/64))$((__c/8%8))$((__c%8))\n");
 #else
-  putstr("    _putchar __ $((_$__addr))\n");
+  putstr("    _putchar __ $__c\n");
 #endif
   putstr("    : $((__addr += 1))\n");
   putstr("  done\n");
@@ -556,8 +556,8 @@ DEFINE_RUNTIME_FUN(printf)
 DEPENDS_ON(put_pstr)
   putstr("read_int() {\n");
   putstr("  __int=\n");
-  putstr("  while [ $((_$__fmt_ptr)) != 0 ] && [ $((_$__fmt_ptr)) -ge 48 ] && [ $((_$__fmt_ptr)) -le 57 ]; do\n");
-  putstr("    __int=\"$__int$((_$__fmt_ptr - 48))\"\n");
+  putstr("  while [ $((__c = _$__fmt_ptr)) != 0 ] && [ $__c -ge 48 ] && [ $__c -le 57 ]; do\n");
+  putstr("    __int=\"$__int$((__c - 48))\"\n");
   putstr("    : $((__fmt_ptr += 1))\n");
   putstr("  done\n");
   putstr("}\n");
@@ -588,8 +588,7 @@ DEPENDS_ON(put_pstr)
   putstr("  __fmt_ptr=$1; shift\n");
   putstr("  __mod_start=0\n");
   putstr("  printf_reset\n");
-  putstr("  while [ \"$((_$__fmt_ptr))\" != 0 ] ; do\n");
-  putstr("    __head=$((_$__fmt_ptr))\n");
+  putstr("  while [ \"$((__head = _$__fmt_ptr))\" != 0 ] ; do\n");
   putstr("    __fmt_ptr=$((__fmt_ptr + 1))\n");
   putstr("    if [ $__mod -eq 1 ] ; then\n");
   call_int_to_char("      ", "$__head")

--- a/shell-benchmarks/bench-puts.c
+++ b/shell-benchmarks/bench-puts.c
@@ -1,0 +1,42 @@
+int atoi(const char* str) {
+  int res = 0;
+  for (;*str != '\0'; ++str) {
+    res = res * 10 + *str - '0';
+  }
+  return res;
+}
+
+char c;
+void puts_fast(char *str) {
+  while (c = *str) {
+    putchar(c);
+    str += 1;
+  }
+}
+
+void puts(char *str) {
+  while (*str) {
+    putchar(*str);
+    str += 1;
+  }
+}
+
+void main(int argc, char** argv) {
+  int count = 1;
+  char *str;
+  if (argc != 4) {
+    puts("Usage: bench-puts <string> <count> <method>\n");
+    exit(1);
+  }
+  str = argv[1];
+  count = atoi(argv[2]);
+  if (argv[3][0] == 'f') {
+    while (count--) {
+      puts_fast(str);
+    }
+  } else {
+    while (count--) {
+      puts(str);
+    }
+  }
+}

--- a/shell-benchmarks/bench-puts.sh
+++ b/shell-benchmarks/bench-puts.sh
@@ -1,0 +1,267 @@
+#!/bin/sh
+set -e -u -f
+LC_ALL=C
+
+: $((res = str = 0))
+_atoi() { let str $2
+  let res
+  res=0
+  while [ $((_$str)) != $__NUL__ ] ; do
+    res=$((((res * 10) + _$str) - __0__))
+    : $((str += 1))
+  done
+  : $(($1 = res))
+  endlet $1 res str
+}
+
+_c=0
+: $((str = 0))
+_puts_fast() { let str $2
+  while [ $((_c = _$str)) != 0 ] ; do
+    printf \\$((_c/64))$((_c/8%8))$((_c%8))
+    : $((str += 1))
+  done
+  endlet $1 str
+}
+
+: $((str = 0))
+_puts() { let str $2
+  while [ $((_$str)) != 0 ] ; do
+    printf \\$(((_$str)/64))$(((_$str)/8%8))$(((_$str)%8))
+    : $((str += 1))
+  done
+  endlet $1 str
+}
+
+: $((str = count = argv_ = argc = 0))
+_main() { let argc $2; let argv_ $3
+  let count; let str
+  count=1
+  if [ $argc != 4 ] ; then
+    printf "Usage: bench-puts <string> <count> <method>\n"
+    exit 1
+  fi
+  str=$((_$((argv_ + 1))))
+  _atoi count $((_$((argv_ + 2))))
+  if [ $((_$((_$((argv_ + 3)) + 0)))) = $__f__ ] ; then
+    while [ $(((count -= 1) + 1)) != 0 ] ; do
+      _puts_fast __ $str
+    done
+  else
+    while [ $(((count -= 1) + 1)) != 0 ] ; do
+      _puts __ $str
+    done
+  fi
+  endlet $1 str count argv_ argc
+}
+
+# Character constants
+readonly __NUL__=0
+readonly __0__=48
+readonly __f__=102
+# Runtime library
+__ALLOC=1 # Starting heap at 1 because 0 is the null pointer.
+
+_malloc() { # $2 = object size
+  : $((_$__ALLOC = $2)) # Track object size
+  : $(($1 = $__ALLOC + 1))
+  : $((__ALLOC += $2 + 1))
+}
+
+__c2i_0=48
+__c2i_1=49
+__c2i_2=50
+__c2i_3=51
+__c2i_4=52
+__c2i_5=53
+__c2i_6=54
+__c2i_7=55
+__c2i_8=56
+__c2i_9=57
+__c2i_a=97
+__c2i_b=98
+__c2i_c=99
+__c2i_d=100
+__c2i_e=101
+__c2i_f=102
+__c2i_g=103
+__c2i_h=104
+__c2i_i=105
+__c2i_j=106
+__c2i_k=107
+__c2i_l=108
+__c2i_m=109
+__c2i_n=110
+__c2i_o=111
+__c2i_p=112
+__c2i_q=113
+__c2i_r=114
+__c2i_s=115
+__c2i_t=116
+__c2i_u=117
+__c2i_v=118
+__c2i_w=119
+__c2i_x=120
+__c2i_y=121
+__c2i_z=122
+__c2i_A=65
+__c2i_B=66
+__c2i_C=67
+__c2i_D=68
+__c2i_E=69
+__c2i_F=70
+__c2i_G=71
+__c2i_H=72
+__c2i_I=73
+__c2i_J=74
+__c2i_K=75
+__c2i_L=76
+__c2i_M=77
+__c2i_N=78
+__c2i_O=79
+__c2i_P=80
+__c2i_Q=81
+__c2i_R=82
+__c2i_S=83
+__c2i_T=84
+__c2i_U=85
+__c2i_V=86
+__c2i_W=87
+__c2i_X=88
+__c2i_Y=89
+__c2i_Z=90
+char_to_int() {
+  case $1 in
+    [[:alnum:]]) __c=$((__c2i_$1)) ;;
+    ' ') __c=32 ;;
+    '!') __c=33 ;;
+    '"') __c=34 ;;
+    '#') __c=35 ;;
+    '$') __c=36 ;;
+    '%') __c=37 ;;
+    '&') __c=38 ;;
+    "'") __c=39 ;;
+    '(') __c=40 ;;
+    ')') __c=41 ;;
+    '*') __c=42 ;;
+    '+') __c=43 ;;
+    ',') __c=44 ;;
+    '-') __c=45 ;;
+    '.') __c=46 ;;
+    '/') __c=47 ;;
+    ':') __c=58 ;;
+    ';') __c=59 ;;
+    '<') __c=60 ;;
+    '=') __c=61 ;;
+    '>') __c=62 ;;
+    '?') __c=63 ;;
+    '@') __c=64 ;;
+    '[') __c=91 ;;
+    '\') __c=92 ;;
+    ']') __c=93 ;;
+    '^') __c=94 ;;
+    '_') __c=95 ;;
+    '`') __c=96 ;;
+    '{') __c=123 ;;
+    '|') __c=124 ;;
+    '}') __c=125 ;;
+    '~') __c=126 ;;
+    *)
+      __c=$(printf "%d" "'$1"); __c=$((__c > 0 ? __c : 256 + __c)) ;;
+  esac
+}
+
+# Convert a Shell string to a C string
+unpack_string() {
+  __str="$2"
+  _malloc $1 $((${#__str} + 1))
+  __ptr=$(($1))
+  __us_buf16=
+  __us_buf256=
+  while [ ! -z "$__str" ] || [ ! -z "$__us_buf256" ] ; do
+  if [ -z "$__us_buf256" ]; then
+    if [ ${#__str} -ge 256 ]; then
+      __temp="${__str#????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????}"
+      __us_buf256="${__str%"$__temp"}"
+      __str="$__temp"
+    else
+      __us_buf256="$__str"
+      __str=
+    fi
+  fi
+  if [ -z "$__us_buf16" ]; then
+    if [ ${#__us_buf256} -ge 16 ]; then
+      __temp="${__us_buf256#????????????????}"
+      __us_buf16="${__us_buf256%"$__temp"}"
+      __us_buf256="$__temp"
+    else
+      __us_buf16="$__us_buf256"
+      __us_buf256=
+    fi
+  fi
+    while [ ! -z "$__us_buf16" ]; do
+      case "$__us_buf16" in
+        " "*) : $((_$__ptr = 32))  ;;
+        "e"*) : $((_$__ptr = 101)) ;;
+        "="*) : $((_$__ptr = 61))  ;;
+        "t"*) : $((_$__ptr = 116)) ;;
+        ";"*) : $((_$__ptr = 59))  ;;
+        "i"*) : $((_$__ptr = 105)) ;;
+        ")"*) : $((_$__ptr = 41))  ;;
+        "("*) : $((_$__ptr = 40))  ;;
+        "n"*) : $((_$__ptr = 110)) ;;
+        "s"*) : $((_$__ptr = 115)) ;;
+        "l"*) : $((_$__ptr = 108)) ;;
+        "+"*) : $((_$__ptr = 43))  ;;
+        "p"*) : $((_$__ptr = 112)) ;;
+        "a"*) : $((_$__ptr = 97))  ;;
+        "r"*) : $((_$__ptr = 114)) ;;
+        "f"*) : $((_$__ptr = 102)) ;;
+        "d"*) : $((_$__ptr = 100)) ;;
+        "*"*) : $((_$__ptr = 42))  ;;
+        *)
+          char_to_int "${__us_buf16%"${__us_buf16#?}"}"
+          : $((_$__ptr = __c))
+          ;;
+      esac
+      __us_buf16=${__us_buf16#?}  # Remove the first character
+      : $((__ptr += 1))           # Move to the next buffer position
+    done
+  done
+  : $((_$__ptr = 0))
+}
+
+make_argv() {
+  __argc=$1; shift;
+  _malloc __argv $__argc # Allocate enough space for all elements. No need to initialize.
+  __argv_ptr=$__argv
+
+  while [ $# -ge 1 ]; do
+    unpack_string _$__argv_ptr "$1"
+    : $((__argv_ptr += 1))
+    shift
+  done
+}
+
+# Local variables
+__=0
+__SP=0
+let() { # $1: variable name, $2: value (optional)
+  : $((__SP += 1)) $((__$__SP=$1)) # Push
+  : $(($1=${2-0}))                 # Init
+}
+endlet() { # $1: return variable
+           # $2...: function local variables
+  __ret=$1 # Don't overwrite return value
+  : $((__tmp = $__ret))
+  while [ $# -ge 2 ]; do
+    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    shift;
+  done
+  : $(($__ret=__tmp))   # Restore return value
+}
+
+# Setup argc, argv
+__argc_for_main=$(($# + 1))
+make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
+_main __ $__argc_for_main $__argv_for_main

--- a/shell-benchmarks/run-bench-puts.sh
+++ b/shell-benchmarks/run-bench-puts.sh
@@ -1,0 +1,17 @@
+str="VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n"
+
+test_with() {
+  hyperfine "$1 shell-benchmarks/bench-puts.sh '$str' 1000 $2 > /dev/null"
+}
+
+test_with "bash" "slow"
+test_with "bash" "fast"
+
+test_with "dash" "slow"
+test_with "dash" "fast"
+
+test_with "ksh" "slow"
+test_with "ksh" "fast"
+
+test_with "zsh" "slow"
+test_with "zsh" "fast"


### PR DESCRIPTION
The affected functions are:

- `_put_pstr`
- `read_int`
- `_printf`

These 3 functions iterate over a string and then read the character again in the next statements. By using `(__c = *__ptr) != 0` in the loop condition, we avoid reading the character again which appears to be faster on all shells.

However, the main motivation for this change is to match the paper's definition of _puts which was too wide to fit in the column.

Benchmarks:

```
  bash shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 slow > /dev/null
    Time (mean ± σ):     832.6 ms ±   2.0 ms    [User: 789.6 ms, System: 41.3 ms]
    Range (min … max):   830.4 ms … 836.5 ms    10 runs

  bash shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 fast > /dev/null
    Time (mean ± σ):     750.9 ms ±   1.8 ms    [User: 708.3 ms, System: 40.8 ms]
    Range (min … max):   747.9 ms … 753.6 ms    10 runs

  dash shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 slow > /dev/null
    Time (mean ± σ):     454.8 ms ±   1.3 ms    [User: 367.3 ms, System: 86.2 ms]
    Range (min … max):   453.4 ms … 457.1 ms    10 runs

  dash shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 fast > /dev/null
    Time (mean ± σ):     429.9 ms ±   2.4 ms    [User: 343.0 ms, System: 86.0 ms]
    Range (min … max):   428.3 ms … 435.8 ms    10 runs

  ksh shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 slow > /dev/null
    Time (mean ± σ):     425.6 ms ±   1.0 ms    [User: 421.4 ms, System: 2.7 ms]
    Range (min … max):   424.2 ms … 427.3 ms    10 runs

  ksh shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 fast > /dev/null
    Time (mean ± σ):     382.0 ms ±   1.1 ms    [User: 378.0 ms, System: 2.4 ms]
    Range (min … max):   380.5 ms … 383.8 ms    10 runs

  zsh shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 slow > /dev/null
    Time (mean ± σ):     708.8 ms ±   2.2 ms    [User: 550.4 ms, System: 155.8 ms]
    Range (min … max):   706.4 ms … 712.7 ms    10 runs

  zsh shell-benchmarks/bench-puts.sh 'VERY LONG STRING TO REDUCE THE OVERHEAD OF EVERYTHING ELSE. DID YOU KNOW THAT THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG?\n' 1000 fast > /dev/null
    Time (mean ± σ):     686.1 ms ±   2.0 ms    [User: 528.5 ms, System: 155.0 ms]
    Range (min … max):   683.0 ms … 689.4 ms    10 runs
```