### PR TITLE
Add metrics workflow and fix measure-file-size.sh script

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,27 @@
+name: metrics
+
+on:
+  pull_request: # Should trigger on pull requests for all branches
+    branches:
+      - '**'  # Matches all branches
+
+jobs:
+  measure-file-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install gcc and clang
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y build-essential bc
+
+      - name: Measure file size
+        run: |
+          sh analysis/measure-file-size.sh
+          if [ $? -ne 0 ]; then
+            echo "Failed to measure file size"
+            exit 1
+          fi

--- a/analysis/measure-file-size.sh
+++ b/analysis/measure-file-size.sh
@@ -1,24 +1,22 @@
 #! /bin/bash
 #
-# With pnut split accross multiple files with many compilation targets and
+# With pnut split across multiple files with many compilation targets and
 # options, the size of the compiler is not trivial to measure. gcc's -E option
 # can be used to expand the preprocessor directives, but it also includes all
 # the code from the #include <> directives which is not code pnut sees and so we
 # need something in between that only expands the active #include "" directives.
 #
 # This script uses the DEBUG_EXPAND_INCLUDES option that preprocess the input
-# and prints the characters that are read. Active #include directive are followed
-# meaning that the included file is printed as well. The output is then filtered
-# to remove the lines that correspond to the included files.
+# and prints the characters that are read. Active #include directive are
+# expanded meaning that the included file is printed as well. The output is then
+# filtered to remove the lines that correspond to the included files.
 #
-# The result is as if someone had manually replaced the active #include directives
-# with the content of the included files.
+# The result is as if someone had manually replaced the active #include
+# directives with the content of the included files.
 #
 # We then run a few tests to make sure the result is correct:
 # - The expanded file still compiles with gcc
 # - The result of pnut on the expanded file is the same as the result of pnut on the original file
-#
-# The
 
 set -e # Exit on error
 

--- a/analysis/measure-file-size.sh
+++ b/analysis/measure-file-size.sh
@@ -20,6 +20,8 @@
 #
 # The
 
+set -e # Exit on error
+
 TEMP_DIR="build/measure"
 mkdir -p "$TEMP_DIR"
 

--- a/pnut.c
+++ b/pnut.c
@@ -2027,7 +2027,7 @@ void get_tok() {
 
 // parser
 
-#ifdef NICE_ERR_MSG
+#if defined DEBUG_CPP || defined DEBUG_EXPAND_INCLUDES || defined NICE_ERR_MSG
 #include "debug.c"
 #endif
 
@@ -3146,13 +3146,7 @@ ast parse_compound_statement() {
 
 //-----------------------------------------------------------------------------
 
-#ifdef DEBUG_CPP
-#include "debug.c"
-#endif
-
 int main(int argc, char **argv) {
-
-
   int i;
   ast decl;
 
@@ -3200,12 +3194,14 @@ int main(int argc, char **argv) {
   while (ch != EOF) {
     get_ch();
   }
-#elif defined DEBUG_CPP || defined DEBUG_EXPAND_INCLUDES // Tokenize input, output tokens
+#elif defined DEBUG_EXPAND_INCLUDES || defined DEBUG_CPP // Tokenize input, output tokens
   get_tok();
 
   while (tok != EOF) {
     skip_newlines = false; // Don't skip newlines so print_tok knows where to break lines
+#if defined DEBUG_CPP
     print_tok(tok, val);
+#endif
     get_tok();
   }
 #elif defined DEBUG_PARSER // Parse input, output nothing


### PR DESCRIPTION
## Context

https://github.com/udem-dlteam/pnut/pull/105 changed a few things and broke the `analysis/measure-file-size.sh` script. Because the script isn't run by CI, it's easy to break so this PR fixes it and adds a metrics workflow to prevent future breakage.

The workflow also prints the size of pnut-sh and other files, which will make it easier to track the change in file size.