### PR TITLE
Build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ all: $(BUILD_DIR)/pnut-sh \
 
 $(BUILD_DIR)/pnut-sh: pnut.c sh.c sh-runtime.c
 	mkdir -p $(BUILD_DIR)
-	$(CC) $(BUILD_OPT_SH) pnut.c -o $(BUILD_DIR)/pnut-sh
+	$(CC) $(CFLAGS) $(BUILD_OPT_SH) pnut.c -o $(BUILD_DIR)/pnut-sh
 
 $(BUILD_DIR)/pnut-sh.sh: $(BUILD_DIR)/pnut-sh
 	./$(BUILD_DIR)/pnut-sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh.sh
@@ -46,7 +46,7 @@ $(BUILD_DIR)/pnut-sh-bootstrapped.sh: $(BUILD_DIR)/pnut-sh.sh pnut.c sh.c sh-run
 
 $(BUILD_DIR)/pnut-exe: pnut.c x86.c exe.c elf.c mach-o.c
 	mkdir -p $(BUILD_DIR)
-	$(CC) $(BUILD_OPT_EXE) pnut.c -o $(BUILD_DIR)/pnut-exe
+	$(CC) $(CFLAGS) $(BUILD_OPT_EXE) pnut.c -o $(BUILD_DIR)/pnut-exe
 
 $(BUILD_DIR)/pnut-exe.sh: $(BUILD_DIR)/pnut-sh pnut.c x86.c exe.c elf.c mach-o.c
 	$(BUILD_DIR)/pnut-sh $(BUILD_OPT_EXE) pnut.c > $(BUILD_DIR)/pnut-exe.sh

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,12 @@ $(BUILD_DIR)/pnut-exe-bootstrapped: $(BUILD_DIR)/pnut-exe
 	$(BUILD_DIR)/pnut-exe $(BUILD_OPT_EXE) pnut.c > $(BUILD_DIR)/pnut-exe-bootstrapped
 
 install: $(BUILD_DIR)/pnut-sh $(BUILD_DIR)/pnut-sh.sh
-	sudo cp $(BUILD_DIR)/pnut-sh /usr/local/bin/pnut
-	sudo cp $(BUILD_DIR)/pnut-sh.sh /usr/local/bin/pnut.sh
+	cp $(BUILD_DIR)/pnut-sh /usr/local/bin/pnut
+	cp $(BUILD_DIR)/pnut-sh.sh /usr/local/bin/pnut.sh
 
 uninstall:
-	sudo $(RM) /usr/local/bin/pnut
-	sudo $(RM) /usr/local/bin/pnut.sh
+	$(RM) /usr/local/bin/pnut
+	$(RM) /usr/local/bin/pnut.sh
 
 clean:
 	$(RM) -r $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ BUILD_OPT_EXE.Linux.x86_64 = -DRELEASE_PNUT_x86_64_linux $(BUILD_OPT)
 BUILD_OPT_EXE.Darwin.x86_64 = -DRELEASE_PNUT_x86_64_mac $(BUILD_OPT)
 BUILD_OPT_EXE.Darwin.arm64 = -DRELEASE_PNUT_x86_64_mac $(BUILD_OPT) # no arm64 backend yet, x86 is emulated on ARM Macs
 
+# Shell for building
+BUILD_SHELL=sh
+
 # Detect the operating system and architecture
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
@@ -38,7 +41,7 @@ $(BUILD_DIR)/pnut-sh.sh: $(BUILD_DIR)/pnut-sh
 	chmod +x $(BUILD_DIR)/pnut-sh.sh
 
 $(BUILD_DIR)/pnut-sh-bootstrapped.sh: $(BUILD_DIR)/pnut-sh.sh pnut.c sh.c sh-runtime.c
-	$$SHELL $(BUILD_DIR)/pnut-sh.sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh-bootstrapped.sh
+	$(BUILD_SHELL) $(BUILD_DIR)/pnut-sh.sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh-bootstrapped.sh
 	diff $(BUILD_DIR)/pnut-sh.sh $(BUILD_DIR)/pnut-sh-bootstrapped.sh
 
 $(BUILD_DIR)/pnut-exe: pnut.c x86.c exe.c elf.c mach-o.c

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ all: $(BUILD_DIR)/pnut-sh \
 	$(BUILD_DIR)/pnut-exe.sh \
 	$(BUILD_DIR)/pnut-exe-bootstrapped
 
+$(BUILD_DIR)/config.mk:
+	./configure
+
+include $(BUILD_DIR)/config.mk
+
 $(BUILD_DIR)/pnut-sh: pnut.c sh.c sh-runtime.c
 	mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(BUILD_OPT_SH) pnut.c -o $(BUILD_DIR)/pnut-sh
@@ -55,13 +60,13 @@ $(BUILD_DIR)/pnut-exe.sh: $(BUILD_DIR)/pnut-sh pnut.c x86.c exe.c elf.c mach-o.c
 $(BUILD_DIR)/pnut-exe-bootstrapped: $(BUILD_DIR)/pnut-exe
 	$(BUILD_DIR)/pnut-exe $(BUILD_OPT_EXE) pnut.c > $(BUILD_DIR)/pnut-exe-bootstrapped
 
-install: $(BUILD_DIR)/pnut-sh $(BUILD_DIR)/pnut-sh.sh
-	cp $(BUILD_DIR)/pnut-sh /usr/local/bin/pnut
-	cp $(BUILD_DIR)/pnut-sh.sh /usr/local/bin/pnut.sh
+install: $(BUILD_DIR)/pnut-sh $(BUILD_DIR)/pnut-sh.sh $(BUILD_DIR)/config.mk
+	install -D $(BUILD_DIR)/pnut-sh $(DESTDIR)$(prefix)/bin/pnut
+	install -D $(BUILD_DIR)/pnut-sh.sh $(DESTDIR)$(prefix)/bin/pnut.sh
 
 uninstall:
-	$(RM) /usr/local/bin/pnut
-	$(RM) /usr/local/bin/pnut.sh
+	$(RM) $(DESTDIR)$(prefix)/bin/pnut
+	$(RM) $(DESTDIR)$(prefix)/bin/pnut.sh
 
 clean:
 	$(RM) -r $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ all: $(BUILD_DIR)/pnut-sh \
 
 $(BUILD_DIR)/pnut-sh: pnut.c sh.c sh-runtime.c
 	mkdir -p $(BUILD_DIR)
-	gcc $(BUILD_OPT_SH) pnut.c -o $(BUILD_DIR)/pnut-sh
+	$(CC) $(BUILD_OPT_SH) pnut.c -o $(BUILD_DIR)/pnut-sh
 
 $(BUILD_DIR)/pnut-sh.sh: $(BUILD_DIR)/pnut-sh
 	./$(BUILD_DIR)/pnut-sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh.sh
@@ -46,7 +46,7 @@ $(BUILD_DIR)/pnut-sh-bootstrapped.sh: $(BUILD_DIR)/pnut-sh.sh pnut.c sh.c sh-run
 
 $(BUILD_DIR)/pnut-exe: pnut.c x86.c exe.c elf.c mach-o.c
 	mkdir -p $(BUILD_DIR)
-	gcc $(BUILD_OPT_EXE) pnut.c -o $(BUILD_DIR)/pnut-exe
+	$(CC) $(BUILD_OPT_EXE) pnut.c -o $(BUILD_DIR)/pnut-exe
 
 $(BUILD_DIR)/pnut-exe.sh: $(BUILD_DIR)/pnut-sh pnut.c x86.c exe.c elf.c mach-o.c
 	$(BUILD_DIR)/pnut-sh $(BUILD_OPT_EXE) pnut.c > $(BUILD_DIR)/pnut-exe.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: pnut-sh pnut-sh.sh pnut-sh-bootstrapped.sh pnut-exe pnut-exe.sh pnut-exe-bootstrapped install uninstall clean test-sh test-i386-linux test-x86_64-linux test-x86_64-mac
-
 BUILD_DIR = build
 
 BUILD_OPT_SH = -DRELEASE_PNUT_SH $(BUILD_OPT)
@@ -20,30 +18,41 @@ $(info !!!!! Defaulting to Linux x86_64 build options !!!!!)
 BUILD_OPT_EXE = $(BUILD_OPT_EXE.Linux.x86_64)
 endif
 
-pnut-sh: pnut.c sh.c sh-runtime.c
+.PHONY: default install uninstall clean test-sh test-i386-linux test-x86_64-linux test-x86_64-mac
+
+default: $(BUILD_DIR)/pnut-sh $(BUILD_DIR)/pnut-exe
+
+all: $(BUILD_DIR)/pnut-sh \
+	$(BUILD_DIR)/pnut-sh.sh \
+	$(BUILD_DIR)/pnut-sh-bootstrapped.sh \
+	$(BUILD_DIR)/pnut-exe \
+	$(BUILD_DIR)/pnut-exe.sh \
+	$(BUILD_DIR)/pnut-exe-bootstrapped
+
+$(BUILD_DIR)/pnut-sh: pnut.c sh.c sh-runtime.c
 	mkdir -p $(BUILD_DIR)
 	gcc $(BUILD_OPT_SH) pnut.c -o $(BUILD_DIR)/pnut-sh
 
-pnut-sh.sh: pnut-sh
+$(BUILD_DIR)/pnut-sh.sh: $(BUILD_DIR)/pnut-sh
 	./$(BUILD_DIR)/pnut-sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh.sh
 	chmod +x $(BUILD_DIR)/pnut-sh.sh
 
-pnut-sh-bootstrapped.sh: pnut-sh
+$(BUILD_DIR)/pnut-sh-bootstrapped.sh: $(BUILD_DIR)/pnut-sh
 	$$SHELL $(BUILD_DIR)/pnut-sh.sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh-bootstrapped.sh
 	diff $(BUILD_DIR)/pnut-sh.sh $(BUILD_DIR)/pnut-sh-bootstrapped.sh
 
-pnut-exe: pnut.c x86.c exe.c elf.c mach-o.c
+$(BUILD_DIR)/pnut-exe: pnut.c x86.c exe.c elf.c mach-o.c
 	mkdir -p $(BUILD_DIR)
 	gcc $(BUILD_OPT_EXE) pnut.c -o $(BUILD_DIR)/pnut-exe
 
-pnut-exe.sh: pnut-sh pnut.c x86.c exe.c elf.c mach-o.c
-	./$(BUILD_DIR)/pnut-sh $(BUILD_OPT_EXE) pnut.c > $(BUILD_DIR)/pnut-exe.sh
+$(BUILD_DIR)/pnut-exe.sh: $(BUILD_DIR)/pnut-sh pnut.c x86.c exe.c elf.c mach-o.c
+	$(BUILD_DIR)/pnut-sh $(BUILD_OPT_EXE) pnut.c > $(BUILD_DIR)/pnut-exe.sh
 	chmod +x $(BUILD_DIR)/pnut-exe.sh
 
-pnut-exe-bootstrapped: pnut-exe
+$(BUILD_DIR)/pnut-exe-bootstrapped: $(BUILD_DIR)/pnut-exe
 	$(BUILD_DIR)/pnut-exe $(BUILD_OPT_EXE) pnut.c > $(BUILD_DIR)/pnut-exe-bootstrapped
 
-install: pnut-sh pnut-sh.sh
+install: $(BUILD_DIR)/pnut-sh $(BUILD_DIR)/pnut-sh.sh
 	sudo cp $(BUILD_DIR)/pnut-sh /usr/local/bin/pnut
 	sudo cp $(BUILD_DIR)/pnut-sh.sh /usr/local/bin/pnut.sh
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(BUILD_DIR)/pnut-sh.sh: $(BUILD_DIR)/pnut-sh
 	./$(BUILD_DIR)/pnut-sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh.sh
 	chmod +x $(BUILD_DIR)/pnut-sh.sh
 
-$(BUILD_DIR)/pnut-sh-bootstrapped.sh: $(BUILD_DIR)/pnut-sh
+$(BUILD_DIR)/pnut-sh-bootstrapped.sh: $(BUILD_DIR)/pnut-sh.sh pnut.c sh.c sh-runtime.c
 	$$SHELL $(BUILD_DIR)/pnut-sh.sh $(BUILD_OPT_SH) pnut.c > $(BUILD_DIR)/pnut-sh-bootstrapped.sh
 	diff $(BUILD_DIR)/pnut-sh.sh $(BUILD_DIR)/pnut-sh-bootstrapped.sh
 

--- a/configure
+++ b/configure
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+help='
+Configure a pnut compilation.
+
+--help              display help and exit
+--prefix=PATH       installation prefix
+'
+
+set -e
+
+# Defaults
+prefix="/usr/local"
+
+# read options
+for opt in "$@" ; do
+	case "$opt" in
+	--help)
+		echo "$help"
+		exit 0
+		;;
+	--prefix=*)
+		prefix="${opt#--prefix=}"
+		;;
+	*)
+		echo "Error:  option \"$opt\" unknown." 1>&2
+		exit 1
+	esac
+done
+
+# Create config.mk
+mkdir -p build
+cat > build/config.mk <<EOF
+prefix=${prefix}
+EOF


### PR DESCRIPTION
Implement a number of improvements to the build system
- Use explicit rather than phony targets, so make can track dependencies.
- Implement ./configure for easier integration into packaging scripts and build environments
- Use standardized Makefile variables like CC, CFLAGS, RM, etc.
- No implicit root