### PR TITLE
Fix ./run-pnut-variant.sh --tokenizer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,6 +238,25 @@ jobs:
           sudo chroot woody /bin/bash -c "cd /pnut && PNUT_OPTIONS='-DRT_FREE_UNSETS_VARS_NOT' ./bootstrap-pnut-exe.sh --backend i386_linux --fast"
           sudo chroot woody /bin/bash -c "cd /pnut && PNUT_OPTIONS='-DRT_FREE_UNSETS_VARS_NOT' ./bootstrap-pnut-exe.sh --backend i386_linux --shell bash --fast"
 
+  pnut-variants-run:
+    strategy:
+      matrix:
+        variant: ["reader", "tokenizer", "parser"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install ksh shell
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y coreutils time ksh
+
+      - name: Build with warnings
+        run: |
+          set -e
+          bash ./run-pnut-variant.sh --${{ matrix.variant }} --shell ksh
 
   success-message:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
             brew install coreutils
           else
             sudo apt-get update
-            sudo apt-get install -y coreutils
+            sudo apt-get install -y coreutils time
           fi
 
       - name: Run ${{ matrix.target }} tests on ${{ matrix.host }}
@@ -110,7 +110,7 @@ jobs:
       - name: Install ${{ matrix.shell }} shell
         run: |
           sudo apt-get update
-          sudo apt-get install -y coreutils ${{ matrix.shell }}
+          sudo apt-get install -y coreutils time ${{ matrix.shell }}
 
       - name: Run tests with ${{ matrix.shell }}
         run: |
@@ -124,7 +124,7 @@ jobs:
   bootstrap-pnut-sh:
     strategy:
       matrix:
-        shell: ["bash", "dash", "ksh", "mksh", "yash", "zsh"]
+        shell: ["ksh"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -133,12 +133,12 @@ jobs:
       - name: Install ${{ matrix.shell }} shell
         run: |
           sudo apt-get update
-          sudo apt-get install -y coreutils ${{ matrix.shell }}
+          sudo apt-get install -y coreutils time ${{ matrix.shell }}
 
       - name: Bootstrap pnut-sh.sh on ${{ matrix.shell }}
         run: |
           set -e
-          ./bootstrap-pnut-sh.sh --shell ${{ matrix.shell }} --fast
+          ksh ./bootstrap-pnut-sh.sh --shell ${{ matrix.shell }} --fast
 
   bootstrap-pnut-exe:
     strategy:
@@ -163,7 +163,7 @@ jobs:
             brew install coreutils ${{ matrix.shell }}
           else
             sudo apt-get update
-            sudo apt-get install -y coreutils ${{ matrix.shell }}
+            sudo apt-get install -y coreutils time ${{ matrix.shell }}
           fi
 
       - name: Bootstrap pnut-exe with ${{ matrix.target }} backend
@@ -198,7 +198,7 @@ jobs:
             brew install coreutils
           else
             sudo apt-get update
-            sudo apt-get install -y coreutils
+            sudo apt-get install -y coreutils time
           fi
 
       - name: Bootstrap pnut-sh with pnut-exe on ${{ matrix.target }} backend

--- a/bootstrap-pnut-sh.sh
+++ b/bootstrap-pnut-sh.sh
@@ -12,7 +12,7 @@ bootstrap_with_shell() {
 
   echo "Bootstrap with $1"
 
-  time $1 "$TEMP_DIR/pnut-sh.sh" $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-sh-twice-bootstrapped.sh"
+  /usr/bin/time $1 "$TEMP_DIR/pnut-sh.sh" $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-sh-twice-bootstrapped.sh"
 
   diff "$TEMP_DIR/pnut-sh.sh" "$TEMP_DIR/pnut-sh-twice-bootstrapped.sh"
 

--- a/debug.c
+++ b/debug.c
@@ -11,6 +11,16 @@ void print_string_char(int c) {
   else putchar(c);
 }
 
+void print_tok_string(int string_probe) {
+  char *string_start = STRING_BUF(string_probe);
+  char *string_end = string_start + STRING_LEN(string_probe);
+
+  while (string_start < string_end) {
+    print_string_char(*string_start);
+    string_start += 1;
+  }
+}
+
 int print_tok_indent = 0;
 void print_tok(int tok, int val) {
   int i;
@@ -88,11 +98,7 @@ void print_tok(int tok, int val) {
     putchar('\'');
   } else if (tok == STRING) {
     putchar('"');
-    i = 0;
-    while (string_pool[val+i] != 0) {
-      print_string_char(string_pool[val+i]);
-      i += 1;
-    }
+    print_tok_string(val);
     putchar('"');
   } else if (tok == MACRO_ARG) {
     putstr("ARG["); putint(val); putstr("]");

--- a/pnut.c
+++ b/pnut.c
@@ -429,6 +429,10 @@ ast clone_ast(ast orig) {
   return ast_result;
 }
 
+// Simple accessor to get the string from the string pool
+#define STRING_BUF(string_val) (string_pool + heap[string_val+1])
+#define STRING_LEN(string_val) (heap[string_val+4])
+
 void begin_string() {
   string_start = string_pool_alloc;
   hash = 0;
@@ -482,8 +486,6 @@ int end_ident_i;
 // Like end_ident, but for strings instead of identifiers
 // We want to deduplicate strings to reuse memory if possible.
 #define end_string end_ident
-// Simple accessor to get the string from the string pool
-#define STRING_BUF(string_val) (string_pool + heap[string_val+1])
 
 int end_ident() {
   string_pool[string_pool_alloc] = 0; // terminate string

--- a/run-pnut-variant.sh
+++ b/run-pnut-variant.sh
@@ -13,7 +13,7 @@ run_with_shell() {
 
   echo "Running $variant with $1"
 
-  time $1 "$TEMP_DIR/pnut-$variant.sh" $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-$variant.output"
+  /usr/bin/time $1 "$TEMP_DIR/pnut-$variant.sh" $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-$variant.output"
 }
 
 # Parse the arguments


### PR DESCRIPTION
In https://github.com/udem-dlteam/pnut/pull/106, the `val` associated with a `STRING` token was changed from the index in the string pool to a reference to the hash table probe. I forgot to change the code in debug.c which expected the old behavior.

This commit fixes the issue by updating the code in debug.c, supporting at the same time STRING tokens containing NUL characters, and adds a CI job to make sure we don't break the `./run-pnut-variant` script again by accident.