### PR TITLE
Support __{FILE,LINE,DATE,TIME,TIMESTAMP}__ macros

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -866,6 +866,13 @@ int WRITE_ID;
 int OPEN_ID;
 int CLOSE_ID;
 
+// Macros that are defined by the preprocessor
+int FILE__ID;
+int LINE__ID;
+int DATE__ID;
+int TIME__ID;
+int TIMESTAMP__ID;
+
 // When we parse a macro, we generally want the tokens as they are, without expanding them.
 void get_tok_macro() {
   bool prev_expand_macro = expand_macro;
@@ -1260,8 +1267,7 @@ void get_ident() {
   tok = heap[val+2];
 }
 
-int init_ident(int tok, char *name) {
-
+int intern_str(char* name) {
   int i = 0;
   int prev_ch = ch; // The character may be important to the calling function, saving it
 
@@ -1273,12 +1279,16 @@ int init_ident(int tok, char *name) {
     i += 1;
   }
 
-  i = end_ident();
-
-  heap[i+2] = tok;
+  i = end_string();
 
   ch = prev_ch;
 
+  return i;
+}
+
+int init_ident(int tok, char *name) {
+  int i = intern_str(name);
+  heap[i+2] = tok;
   return i;
 }
 
@@ -1364,8 +1374,28 @@ void init_ident_table() {
   NOT_SUPPORTED_ID = init_ident(IDENTIFIER, "NOT_SUPPORTED");
 }
 
+void init_builtin_string_macro(int macro_id, char* value) {
+  // Macro object shape: ([(tok, val)], arity). -1 arity means it's an object-like macro
+  heap[macro_id + 3] = cons(cons(cons(STRING, intern_str(value)), 0), -1);
+}
+
+void init_builtin_int_macro(int macro_id, int value) {
+  heap[macro_id + 3] = cons(cons(cons(INTEGER, -value), 0), -1);
+}
+
 void init_pnut_macros() {
   init_ident(MACRO, "PNUT_CC");
+  FILE__ID      = init_ident(MACRO, "__FILE__");
+  LINE__ID      = init_ident(MACRO, "__LINE__");
+  DATE__ID      = init_ident(MACRO, "__DATE__");
+  TIME__ID      = init_ident(MACRO, "__TIME__");
+  TIMESTAMP__ID = init_ident(MACRO, "__TIMESTAMP__");
+
+  init_builtin_string_macro(FILE__ID, "<unknown>");
+  init_builtin_int_macro   (LINE__ID, 0);
+  init_builtin_string_macro(DATE__ID, "Jan  1 1970");
+  init_builtin_string_macro(TIME__ID, "00:00:00");
+  init_builtin_string_macro(TIMESTAMP__ID, "Jan  1 1970 00:00:00");
 }
 
 // A macro argument is represented using a list of tokens.
@@ -1487,7 +1517,18 @@ bool attempt_macro_expansion(int macro) {
   int tokens = car(heap[macro + 3]);
   macro = val;
   if (cdr(heap[macro + 3]) == -1) { // Object-like macro
-    play_macro(tokens, 0);
+    // Note: We don't check if the macro was redefined by the program
+    if (macro == FILE__ID) {
+      play_macro(cons(cons(STRING, intern_str(fp_filepath)), 0), 0);
+    }
+#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
+    else if (macro == LINE__ID) {
+      play_macro(cons(cons(INTEGER, -line_number), 0), 0);
+    }
+#endif
+    else {
+      play_macro(tokens, 0);
+    }
     return true;
   } else {
     new_macro_args = get_macro_args_toks(macro);

--- a/pnut.c
+++ b/pnut.c
@@ -1517,7 +1517,8 @@ bool attempt_macro_expansion(int macro) {
   int tokens = car(heap[macro + 3]);
   macro = val;
   if (cdr(heap[macro + 3]) == -1) { // Object-like macro
-    // Note: We don't check if the macro was redefined by the program
+    // Note: Redefining __{FILE,LINE}__ macros, either with the #define or #line
+    // directives is not supported.
     if (macro == FILE__ID) {
       play_macro(cons(cons(STRING, intern_str(fp_filepath)), 0), 0);
     }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,9 +51,14 @@ esac
 compile_pnut() { # extra pnut compilation options: $1
   pnut_source="pnut.c"
   extra_opts="$1"
-  extra_opts_id=$(printf "%s" $extra_opts | base64)
-  pnut_exe="./tests/pnut-by-gcc-$extra_opts_id.exe"
-  pnut_exe_backend="./tests/pnut-$extra_opts_id.$ext"
+  if [ -z "$extra_opts" ]; then
+    extra_opts_id="base"
+  else
+    extra_opts_id=$(printf "%s" "$extra_opts" | md5sum | cut -c 1-16) # 16 characters should be enough
+  fi
+  extra_opts_suffix=${extra_opts_id:+"-"}$extra_opts_id             # Add a dash if there are extra options
+  pnut_exe="./tests/pnut-by-gcc${extra_opts_suffix}.exe"
+  pnut_exe_backend="./tests/pnut-$extra_opts_suffix.$ext"
 
   if [ ! -f "$pnut_exe" ]; then
     gcc "$pnut_source" $PNUT_EXE_OPTIONS $extra_opts -o "$pnut_exe" 2> /dev/null || fail "Error: Failed to compile $pnut_source with $backend"

--- a/tests/_all/preprocessor/macro/builtin-stubbed.c
+++ b/tests/_all/preprocessor/macro/builtin-stubbed.c
@@ -1,0 +1,46 @@
+// tests for __FILE__, __LINE__, __DATE__, __TIME__, __TIMESTAMP__ built-in macros
+#include <stdio.h>
+
+#ifndef __FILE__
+#error "__FILE__ is not defined"
+#endif
+#ifndef __LINE__
+#error "__LINE__ is not defined"
+#endif
+#ifndef __DATE__
+#error "__DATE__ is not defined"
+#endif
+#ifndef __TIME__
+#error "__TIME__ is not defined"
+#endif
+#ifndef __TIMESTAMP__
+#error "__TIMESTAMP__ is not defined"
+#endif
+
+void putint(int n) {
+  if (n < 0) {
+    putchar('-');
+    putint(-n);
+  } else if (n > 9) {
+    putint(n / 10);
+    putchar('0' + n % 10);
+  } else {
+    putchar('0' + n);
+  }
+}
+
+void putstr(char *str) {
+  while (*str) {
+    putchar(*str);
+    str += 1;
+  }
+}
+
+int main() {
+  putstr(__FILE__);      putchar('\n');
+  putint(__LINE__);      putchar('\n');
+  putstr(__DATE__);      putchar('\n');
+  putstr(__TIME__);      putchar('\n');
+  putstr(__TIMESTAMP__); putchar('\n');
+  return 0;
+}

--- a/tests/_all/preprocessor/macro/builtin-stubbed.golden
+++ b/tests/_all/preprocessor/macro/builtin-stubbed.golden
@@ -1,0 +1,5 @@
+tests/_all/preprocessor/macro/builtin-stubbed.c
+0
+Jan  1 1970
+00:00:00
+Jan  1 1970 00:00:00

--- a/tests/_all/preprocessor/macro/builtin.c
+++ b/tests/_all/preprocessor/macro/builtin.c
@@ -1,0 +1,3 @@
+// tests for __FILE__, __LINE__, __DATE__, __TIME__, __TIMESTAMP__ built-in macros
+// comp_pnut_opt: -DINCLUDE_LINE_NUMBER_ON_ERROR
+#include "builtin-stubbed.c"

--- a/tests/_all/preprocessor/macro/builtin.golden
+++ b/tests/_all/preprocessor/macro/builtin.golden
@@ -1,0 +1,5 @@
+tests/_all/preprocessor/macro/builtin-stubbed.c
+41
+Jan  1 1970
+00:00:00
+Jan  1 1970 00:00:00


### PR DESCRIPTION
## Context

It was pointed out in https://github.com/udem-dlteam/pnut/issues/124 that pnut doesn't support the `__FILE__` and `__LINE__` built-in macros. This PR adds support for these macros and `__{DATE,TIME,TIMESTAMP}__` for conformance with the standard.

Support for `__FILE__` was relatively simple as we already keep track of the current file name. Same thing for  `__LINE__` as the line number is already computed when `INCLUDE_LINE_NUMBER_ON_ERROR` is activated (0 is used otherwise). The value for the other macros are hard coded to time 0 (`Jan 1 1970`/ `00:00:00`) for simplicity.

In principle ([C99 standard document](https://www.dii.uchile.cl/~daespino/files/Iso_C_1999_definition.pdf) section 6.10.8), the `_ _STDC*_ _` macros should also be defined but pnut is far from respecting the full C99 standard so I think it's better to keep them undefined for now.