### PR TITLE
Only produce color error message when outputting to terminal

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -2104,10 +2104,12 @@ void parse_error(char *msg, int token) {
   putstr("  Location: ");
   change_color(ANSI_GREEN);
   putstr(include_stack->filepath);
+#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
   putchar(':');
   putint(last_tok_line_number);
   putchar(':');
   putint(last_tok_column_number);
+#endif
   putchar('\n');
   exit(1);
 }

--- a/pnut.c
+++ b/pnut.c
@@ -5,6 +5,7 @@
 #include <strings.h>
 #include <string.h>
 #include <stdint.h> // for intptr_t
+#include <unistd.h> // for isatty
 
 #define ast int
 #define true 1
@@ -2059,49 +2060,62 @@ void get_tok() {
 #include "debug.c"
 #endif
 
-
-
-void parse_error(char * msg, int token) {
-
 #ifdef NICE_ERR_MSG
-  #define ANSI_RED     "\x1b[31m"
-  #define ANSI_GREEN   "\x1b[32m"
-  #define ANSI_YELLOW  "\x1b[33m"
-  #define ANSI_BLUE    "\x1b[34m"
-  #define ANSI_MAGENTA "\x1b[35m"
-  #define ANSI_CYAN    "\x1b[36m"
-  #define ANSI_RESET   "\x1b[0m"
+#define ANSI_RED     "\x1b[31m"
+#define ANSI_GREEN   "\x1b[32m"
+#define ANSI_YELLOW  "\x1b[33m"
+#define ANSI_BLUE    "\x1b[34m"
+#define ANSI_MAGENTA "\x1b[35m"
+#define ANSI_CYAN    "\x1b[36m"
+#define ANSI_RESET   "\x1b[0m"
 
-  //Error header
-  putstr(ANSI_RED"Error occurred while parsing ");
-  putstr(ANSI_GREEN"\"");
+void change_color(char *color) {
+  if (isatty(1)) { // Only output color codes if stdout is a terminal
+    putstr(color);
+  }
+}
+
+void parse_error(char *msg, int token) {
+  // Error header
+  change_color(ANSI_RED);
+  putstr("Error occurred while parsing ");
+  change_color(ANSI_GREEN);
+  putchar('"');
   putstr(include_stack->filepath);
-  putstr("\""ANSI_RESET"\n");
+  putchar('"');
+  putchar('\n');
 
-  //Error message
-  putstr("  Message: "ANSI_YELLOW);
+  // Error message
+  change_color(ANSI_RESET);
+  putstr("  Message: ");
+  change_color(ANSI_YELLOW);
   putstr(msg);
-  putstr(ANSI_RESET"\n");
+  putchar('\n');
 
-  //Error token
-  putstr("  Offending Token: "ANSI_YELLOW);
+  // Error token
+  change_color(ANSI_RESET);
+  putstr("  Offending Token: ");
+  change_color(ANSI_YELLOW);
   print_tok_type(token);
-  putstr(ANSI_RESET"\n");
+  putchar('\n');
 
-  //Error location
-  putstr("  Location: "ANSI_GREEN);
+  // Error location
+  change_color(ANSI_RESET);
+  putstr("  Location: ");
+  change_color(ANSI_GREEN);
   putstr(include_stack->filepath);
   putchar(':');
   putint(last_tok_line_number);
   putchar(':');
   putint(last_tok_column_number);
-  putstr(ANSI_RESET"\n");
-#else
-  fatal_error(msg);
-#endif
+  putchar('\n');
   exit(1);
 }
-
+#else
+void parse_error(char *msg, int token) {
+  fatal_error(msg);
+}
+#endif
 
 void expect_tok(int expected_tok) {
   if (tok != expected_tok) {

--- a/pnut.c
+++ b/pnut.c
@@ -865,6 +865,7 @@ int READ_ID;
 int WRITE_ID;
 int OPEN_ID;
 int CLOSE_ID;
+int ISATTY_ID;
 
 // Macros that are defined by the preprocessor
 int FILE__ID;
@@ -1368,6 +1369,7 @@ void init_ident_table() {
   WRITE_ID   = init_ident(IDENTIFIER, "write");
   OPEN_ID    = init_ident(IDENTIFIER, "open");
   CLOSE_ID   = init_ident(IDENTIFIER, "close");
+  ISATTY_ID  = init_ident(IDENTIFIER, "isatty");
 
   // Stringizing is recognized by the macro expander, but it returns a hardcoded
   // string instead of the actual value. This may be enough to compile TCC.

--- a/sh-runtime.c
+++ b/sh-runtime.c
@@ -909,6 +909,12 @@ DEPENDS_ON(read_byte)
   putstr("}\n");
 END_RUNTIME_FUN(fgetc)
 
+DEFINE_RUNTIME_FUN(isatty)
+  putstr("_isatty() { # $2: fd\n");
+  putstr("  [ -t $2 ] && : $(($1 = 1)) || : $(($1 = 0))\n");
+  putstr("}\n");
+END_RUNTIME_FUN(fgetc)
+
 void produce_runtime() {
   if (runtime_use_defstr)     runtime_defstr();
   if (runtime_use_putchar)    runtime_putchar();
@@ -925,6 +931,7 @@ void produce_runtime() {
   if (runtime_use_write)      runtime_write();
   if (runtime_use_open)       runtime_open();
   if (runtime_use_close)      runtime_close();
+  if (runtime_use_isatty)     runtime_isatty();
   if (runtime_use_make_argv)  runtime_make_argv();
   if (runtime_use_local_vars) runtime_local_vars();
   if (runtime_use_unpack_string) runtime_unpack_string();

--- a/sh.c
+++ b/sh.c
@@ -1678,6 +1678,7 @@ text comp_fun_call_code(ast node, ast assign_to) {
   else if (name_id == WRITE_ID)   { runtime_use_write = true; }
   else if (name_id == OPEN_ID)    { runtime_use_open = true; }
   else if (name_id == CLOSE_ID)   { runtime_use_close = true; }
+  else if (name_id == ISATTY_ID)  { runtime_use_isatty = true; }
 
   return string_concat3(
     function_name(get_val(name)),


### PR DESCRIPTION
## Context

In https://github.com/udem-dlteam/pnut/pull/121, we added color to some of the error messages produced by pnut (when `NICE_ERR_MSG` is on). Howver, we forgot to take into account that the output of pnut is often redirected to a file, where we don't want to see color codes.

Fortunately, the `test` POSIX shell utility can be used to check what a file descriptor is a terminal, which allows pnut to only output color codes when stdout is a terminal.

> -t  file_descriptor
>    True if file descriptor number file_descriptor is open and is associated with a terminal. False if file_descriptor is not a valid file descriptor number, or if file descriptor number file_descriptor is not open, or if it is open but is not associated with a terminal.

