### PR TITLE
Map putchar('{char}') calls to printf '{char}`

### DIFF
--- a/examples/compiled/base64.sh
+++ b/examples/compiled/base64.sh
@@ -84,15 +84,15 @@ _encode() {
     printf \\$(((_$((_codes + (b1 >> 2))))/64))$(((_$((_codes + (b1 >> 2))))/8%8))$(((_$((_codes + (b1 >> 2))))%8))
     if [ $b2 -lt 0 ] ; then
       printf \\$(((_$((_codes + (63 & (b1 << 4)))))/64))$(((_$((_codes + (63 & (b1 << 4)))))/8%8))$(((_$((_codes + (63 & (b1 << 4)))))%8))
-      printf \\$(((__EQ__)/64))$(((__EQ__)/8%8))$(((__EQ__)%8))
-      printf \\$(((__EQ__)/64))$(((__EQ__)/8%8))$(((__EQ__)%8))
+      printf "="
+      printf "="
       break
     else
       printf \\$(((_$((_codes + (63 & ((b1 << 4) | (b2 >> 4))))))/64))$(((_$((_codes + (63 & ((b1 << 4) | (b2 >> 4))))))/8%8))$(((_$((_codes + (63 & ((b1 << 4) | (b2 >> 4))))))%8))
       _getchar b3
       if [ $b3 -lt 0 ] ; then
         printf \\$(((_$((_codes + (63 & (b2 << 2)))))/64))$(((_$((_codes + (63 & (b2 << 2)))))/8%8))$(((_$((_codes + (63 & (b2 << 2)))))%8))
-        printf \\$(((__EQ__)/64))$(((__EQ__)/8%8))$(((__EQ__)%8))
+        printf "="
         break
       else
         printf \\$(((_$((_codes + (63 & ((b2 << 2) | (b3 >> 6))))))/64))$(((_$((_codes + (63 & ((b2 << 2) | (b3 >> 6))))))/8%8))$(((_$((_codes + (63 & ((b2 << 2) | (b3 >> 6))))))%8))
@@ -164,7 +164,6 @@ _main() { let argc $2; let myargv $3
 readonly __NUL__=0
 readonly __NEWLINE__=10
 readonly __MINUS__=45
-readonly __EQ__=61
 readonly __d__=100
 # Runtime library
 __stdin_buf=

--- a/examples/compiled/sha256sum.sh
+++ b/examples/compiled/sha256sum.sh
@@ -206,8 +206,8 @@ _process_file() { let filename $2
     _hex __ $h
     : $((i += 1))
   done
-  printf \\$(((__SPACE__)/64))$(((__SPACE__)/8%8))$(((__SPACE__)%8))
-  printf \\$(((__SPACE__)/64))$(((__SPACE__)/8%8))$(((__SPACE__)%8))
+  printf " "
+  printf " "
   while [ $((_$filename)) != 0 ]; do
     printf \\$(((_$filename)/64))$(((_$filename)/8%8))$(((_$filename)%8))
     : $((filename += 1))
@@ -233,7 +233,6 @@ _main() { let argc $2; let myargv $3
 
 # Character constants
 readonly __NEWLINE__=10
-readonly __SPACE__=32
 # Runtime library
 
 unpack_escaped_string() {

--- a/sh.c
+++ b/sh.c
@@ -1445,15 +1445,21 @@ text fun_call_params(ast params) {
 
 #ifdef INCLUDE_COMP_PUTCHAR_INLINE
 text comp_putchar_inline(ast param) {
-  text res = comp_rvalue(param, RVALUE_CTX_ARITH_EXPANSION);
+  text res;
   ast ident;
+
+  if (get_op(param) == CHARACTER && get_val(param) >= 32 && get_val(param) <= 126) { // Printable ASCII characters
+    return string_concat3(wrap_str_lit("printf \""), escape_text(wrap_char(get_val(param)), true), wrap_char('\"'));
+  }
+
+  res = comp_rvalue(param, RVALUE_CTX_ARITH_EXPANSION);
 
   if (contains_side_effects) {
     ident = fresh_ident();
     append_glo_decl(string_concat4(comp_lvalue(ident), wrap_str_lit("=$(("), res, wrap_str_lit("))")));
     res = comp_lvalue(ident);
   } else if (get_op(param) != IDENTIFIER) {
-    res = string_concat3(wrap_char('('), res, wrap_char(')'));
+    res = string_concat3(wrap_char('('), res, wrap_char(')')); // Wrap in parentheses to avoid priority of operations issues
   }
 
   res =


### PR DESCRIPTION
This saves a few seconds on dash, and makes the code easier to read. It compromises slightly from our principle of generating "regular" code without any special cases, but the original code looked bad and was harder to read so I think it's worth it.