### PR TITLE
Make measure-file-size.sh compatible with __FILE__

### DIFF
--- a/analysis/measure-file-size.sh
+++ b/analysis/measure-file-size.sh
@@ -36,8 +36,14 @@ expand_includes() { # $1 = output-name, $2 = options
   ./$TEMP_DIR/pnut-sh.exe pnut.c $2 > "$TEMP_DIR/$1.sh"
   ./$TEMP_DIR/pnut-sh.exe "$TEMP_DIR/$1.c" $2 > "$TEMP_DIR/$1-preincluded.sh"
 
-  diff -q "$TEMP_DIR/$1.sh" "$TEMP_DIR/$1-preincluded.sh" || \
-    { echo "Error: $1.sh and $1-preincluded.sh differ"; exit 1; }
+  # Because we use the __FILE__ macro in pnut, the preincluded.sh file will have
+  # a different path than the original file. We need to replace the path in the
+  # preincluded file with the path of the original file.
+  # Note: | is used as the delimiter because the path contains /
+  cat "$TEMP_DIR/$1-preincluded.sh" | sed "s|$TEMP_DIR/$1.c|pnut.c|" > "$TEMP_DIR/$1-preincluded-canonical.sh"
+
+  diff -q "$TEMP_DIR/$1.sh" "$TEMP_DIR/$1-preincluded-canonical.sh" || \
+    { echo "Error: $1.sh and $1-preincluded-canonical.sh differ"; exit 1; }
 }
 
 included_files() {


### PR DESCRIPTION
## Context

https://github.com/udem-dlteam/pnut/pull/123 is adding a use of `__FILE__` in pnut and [it's breaking the `measure-file-size.sh` script and CI check](https://github.com/udem-dlteam/pnut/pull/123#issuecomment-2574287461). This is because `__FILE__` is different between 2 compilations of pnut and it breaks the `diff file1 file2` sanity check.

Instead of the workaround I suggested earlier in my message, it's simpler to fix the script so it takes into account the small difference between the 2 files.