### PR TITLE
Add safe get_child functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,9 +99,6 @@ jobs:
     strategy:
       matrix:
         shell: ["bash", "dash", "ksh", "mksh", "yash", "zsh"]
-        include:
-          - shell: dash # Using dash because it's the fastest
-            pnut_opts: "'-DSH_SAVE_VARS_WITH_SET' '-DOPTIMIZE_CONSTANT_PARAM'"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -116,10 +113,11 @@ jobs:
         run: |
           set -e
           ./run-tests.sh sh --shell ${{ matrix.shell }}
-          for pnut_opts in ${{ matrix.pnut_opts }}; do
-            echo "Running tests with pnut options: $pnut_opts"
-            PNUT_OPTIONS="${pnut_opts}" ./run-tests.sh sh --shell ${{ matrix.shell }}
-          done
+
+      - name: Run tests with ${{ matrix.shell }} (fast)
+        run: |
+          set -e
+          ./run-tests.sh sh --shell ${{ matrix.shell }} --fast
 
   bootstrap-pnut-sh:
     strategy:
@@ -205,6 +203,25 @@ jobs:
         run: |
           set -e
           ./bootstrap-pnut-sh-by-pnut-exe.sh --backend ${{ matrix.target }}
+
+  compile-in-safe-mode:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y coreutils time
+
+      - name: Compile pnut-sh, pnut-exe and tests in safe mode
+        run: |
+          set -e
+          ./bootstrap-pnut-sh.sh --safe --compile-only
+          ./bootstrap-pnut-exe.sh --safe # No compile-only flag for pnut-exe since it's fast enough
+          ./run-tests.sh sh --safe --compile-only
+          ./run-tests.sh i386_linux --safe --compile-only
 
   bootstrap-bash-2_05a:
     runs-on: ubuntu-latest

--- a/bootstrap-pnut-exe.sh
+++ b/bootstrap-pnut-exe.sh
@@ -27,7 +27,11 @@ bootstrap_with_gcc() {
 
   gcc -o $TEMP_DIR/pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c
   # gcc -E -P -DPNUT_CC $PNUT_EXE_OPTIONS pnut.c > "$TEMP_DIR/pnut-after-cpp.c"
-  ./$TEMP_DIR/pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c > $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe
+  ./$TEMP_DIR/pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c > $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe || {
+    echo "Failed to compile pnut-x86-by-pnut-x86-by-gcc.exe"
+    tail -n 20 $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe
+    exit 1
+  }
 
   chmod +x $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe
 

--- a/bootstrap-pnut-exe.sh
+++ b/bootstrap-pnut-exe.sh
@@ -125,12 +125,14 @@ bootstrap_with_shell() {
 # Parse the arguments
 backend="x86_64_linux"  # Default to x86_64_linux
 shell=                  # Defined if doing the full bootstrap using pnut.sh on Posix shell. "all" to test with all shells (slow).
+safe=0                  # Whether to use safe mode when compiling pnut (adds checks at run time)
 
 while [ $# -gt 0 ]; do
   case $1 in
     --backend) backend="$2";                            shift 2 ;;
     --shell)   shell="$2";                              shift 2 ;;
     --fast)    PNUT_SH_OPTIONS="$PNUT_SH_OPTIONS_FAST"; shift 1 ;;
+    --safe)    safe=1;                                  shift 1 ;;
     *) echo "Unknown option: $1"; exit 1;;
   esac
 done
@@ -144,6 +146,9 @@ case $backend in
     exit 1
     ;;
 esac
+
+# Add safe mode if requested
+if [ $safe -eq 1 ]; then PNUT_EXE_OPTIONS="$PNUT_EXE_OPTIONS -DSAFE_MODE"; fi
 
 if [ -z "$shell" ]; then
   bootstrap_with_gcc

--- a/bootstrap-pnut-sh.sh
+++ b/bootstrap-pnut-sh.sh
@@ -21,17 +21,22 @@ bootstrap_with_shell() {
 
 # Parse the arguments
 shell="$SHELL" # Use current shell as the default. "all" to test all shells.
+safe=0
 
 while [ $# -gt 0 ]; do
   case $1 in
-    --shell) shell="$2"; shift 2 ;;
+    --shell) shell="$2";                              shift 2 ;;
     --fast)  PNUT_SH_OPTIONS="$PNUT_SH_OPTIONS_FAST"; shift 1 ;;
+    --safe)  safe=1;                                  shift 1 ;;
     *) echo "Unknown option: $1"; exit 1;;
   esac
 done
 
 if [ ! -d "$TEMP_DIR" ]; then mkdir "$TEMP_DIR"; fi
 
+if [ $safe -eq 1 ]; then PNUT_SH_OPTIONS="$PNUT_SH_OPTIONS -DSAFE_MODE"; fi
+
+echo "PNUT_SH_OPTIONS: $PNUT_SH_OPTIONS"
 gcc -o "$TEMP_DIR/pnut.exe" $PNUT_SH_OPTIONS pnut.c
 
 ./$TEMP_DIR/pnut.exe $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-sh.sh" || {

--- a/bootstrap-pnut-sh.sh
+++ b/bootstrap-pnut-sh.sh
@@ -22,12 +22,14 @@ bootstrap_with_shell() {
 # Parse the arguments
 shell="$SHELL" # Use current shell as the default. "all" to test all shells.
 safe=0
+compile_only=0
 
 while [ $# -gt 0 ]; do
   case $1 in
     --shell) shell="$2";                              shift 2 ;;
     --fast)  PNUT_SH_OPTIONS="$PNUT_SH_OPTIONS_FAST"; shift 1 ;;
     --safe)  safe=1;                                  shift 1 ;;
+    --compile-only) compile_only=1;                   shift 1 ;;
     *) echo "Unknown option: $1"; exit 1;;
   esac
 done
@@ -36,7 +38,6 @@ if [ ! -d "$TEMP_DIR" ]; then mkdir "$TEMP_DIR"; fi
 
 if [ $safe -eq 1 ]; then PNUT_SH_OPTIONS="$PNUT_SH_OPTIONS -DSAFE_MODE"; fi
 
-echo "PNUT_SH_OPTIONS: $PNUT_SH_OPTIONS"
 gcc -o "$TEMP_DIR/pnut.exe" $PNUT_SH_OPTIONS pnut.c
 
 ./$TEMP_DIR/pnut.exe $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-sh.sh" || {
@@ -44,6 +45,12 @@ gcc -o "$TEMP_DIR/pnut.exe" $PNUT_SH_OPTIONS pnut.c
   tail -n 20 "$TEMP_DIR/pnut-sh.sh"
   exit 1
 }
+
+# Exit now if we only want to compile
+if [ $compile_only -eq 1 ]; then
+  echo "Compiled pnut.sh successfully"
+  exit 0;
+fi
 
 if [ "$shell" = "all" ]; then
   set +e # Don't exit on error because we want to test all shells.

--- a/bootstrap-pnut-sh.sh
+++ b/bootstrap-pnut-sh.sh
@@ -34,7 +34,11 @@ if [ ! -d "$TEMP_DIR" ]; then mkdir "$TEMP_DIR"; fi
 
 gcc -o "$TEMP_DIR/pnut.exe" $PNUT_SH_OPTIONS pnut.c
 
-./$TEMP_DIR/pnut.exe $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-sh.sh"
+./$TEMP_DIR/pnut.exe $PNUT_SH_OPTIONS "pnut.c" > "$TEMP_DIR/pnut-sh.sh" || {
+  echo "Failed to compile pnut"
+  tail -n 20 "$TEMP_DIR/pnut-sh.sh"
+  exit 1
+}
 
 if [ "$shell" = "all" ]; then
   set +e # Don't exit on error because we want to test all shells.

--- a/pnut.c
+++ b/pnut.c
@@ -325,6 +325,58 @@ ast get_child(ast node, int i) {
   return heap[node+i+1];
 }
 
+// Because everything is an int in pnut, it's easy to make mistakes and pass the
+// wrong node type to a function. These versions of get_child take the input
+// and/or output node type and checks that the node has the expected type before
+// returning the child node.
+#ifdef SAFE_MODE
+// This function checks that the parent node has the expected operator before
+// returning the child node.
+ast get_child_go(char* file, int line, int expected_parent_node, ast node, int i) {
+  if (get_op(node) != expected_parent_node) {
+    printf("%s:%d: Expected node %d, got %d\n", file, line, expected_parent_node, get_op(node));
+    exit(1);
+  }
+  return heap[node+i+1];
+}
+
+// This function checks that the parent node has the expected operator and that
+// the child node has the expected operator before returning the child node.
+ast get_child__go(char* file, int line, int expected_parent_node, int expected_node, ast node, int i) {
+  if (get_op(node) != expected_parent_node) {
+    printf("%s:%d: Expected node %d, got %d\n", file, line, expected_parent_node, get_op(node));
+    exit(1);
+  }
+  if (get_op(heap[node+i+1]) != expected_node) {
+    printf("%s:%d: Expected child node %d, got %d\n", file, line, expected_node, get_op(heap[node+i+1]));
+    exit(1);
+  }
+  return heap[node+i+1];
+}
+
+// This function checks that the parent node has the expected operator and that
+// the child node has the expected operator (if child node is not 0) before
+// returning the child node.
+ast get_child_opt_go(char* file, int line, int expected_parent_node, int expected_node, ast node, int i) {
+  if (get_op(node) != expected_parent_node) {
+    printf("%s:%d: Expected node %d, got %d\n", file, line, expected_parent_node, get_op(node));
+    exit(1);
+  }
+  if (heap[node+i+1] > 0 && get_op(heap[node+i+1]) != expected_node) {
+    printf("%s:%d: Expected child node %d, got %d\n", file, line, expected_node, get_op(heap[node+i+1]));
+    exit(1);
+  }
+  return heap[node+i+1];
+}
+#define get_child_(expected_parent_node, node, i) get_child_go(__FILE__, __LINE__, expected_parent_node, node, i)
+#define get_child__(expected_parent_node, expected_node, node, i) get_child__go(__FILE__, __LINE__, expected_parent_node, expected_node, node, i)
+#define get_child_opt_(expected_parent_node, expected_node, node, i) get_child_opt_go(__FILE__, __LINE__, expected_parent_node, expected_node, node, i)
+#else
+#define get_child_(expected_parent_node, node, i) get_child(node, i)
+#define get_child__(expected_parent_node, expected_node, node, i) get_child(node, i)
+#define get_child_opt_(expected_parent_node, expected_node, node, i) get_child(node, i)
+#endif
+
 void set_child(ast node, int i, ast child) {
   heap[node+i+1] = child;
 }

--- a/pnut.c
+++ b/pnut.c
@@ -1047,27 +1047,31 @@ int eval_constant(ast expr, bool if_macro) {
   int op = get_op(expr);
   int op1;
   int op2;
+  ast child0, child1;
+
+  if (get_nb_children(expr) >= 1) child0 = get_child(expr, 0);
+  if (get_nb_children(expr) >= 2) child1 = get_child(expr, 1);
 
   switch (op) {
-    case PARENS:    return eval_constant(get_child(expr, 0), if_macro);
+    case PARENS:    return eval_constant(child0, if_macro);
     case INTEGER:   return -get_val(expr);
     case CHARACTER: return get_val(expr);
-    case '~':       return ~eval_constant(get_child(expr, 0), if_macro);
-    case '!':       return !eval_constant(get_child(expr, 0), if_macro);
+    case '~':       return ~eval_constant(child0, if_macro);
+    case '!':       return !eval_constant(child0, if_macro);
     case '-':
     case '+':
-      op1 = eval_constant(get_child(expr, 0), if_macro);
+      op1 = eval_constant(child0, if_macro);
       if (get_nb_children(expr) == 1) {
         return op == '-' ? -op1 : op1;
       } else {
-        op2 = eval_constant(get_child(expr, 1), if_macro);
+        op2 = eval_constant(child1, if_macro);
         return op == '-' ? op1 - op2 : op1 + op2;
       }
 
     case '?':
-      op1 = eval_constant(get_child(expr, 0), if_macro);
+      op1 = eval_constant(child0, if_macro);
       if (op1) {
-        return eval_constant(get_child(expr, 1), if_macro);
+        return eval_constant(child1, if_macro);
       } else {
         return eval_constant(get_child(expr, 2), if_macro);
       }
@@ -1086,8 +1090,8 @@ int eval_constant(ast expr, bool if_macro) {
     case GT_EQ:
     case '<':
     case '>':
-      op1 = eval_constant(get_child(expr, 0), if_macro);
-      op2 = eval_constant(get_child(expr, 1), if_macro);
+      op1 = eval_constant(child0, if_macro);
+      op2 = eval_constant(child1, if_macro);
       switch (op) {
         case '*':     return op1 * op2;
         case '/':     return op1 / op2;
@@ -1107,18 +1111,18 @@ int eval_constant(ast expr, bool if_macro) {
       return 0; // Should never reach here
 
     case AMP_AMP:
-      op1 = eval_constant(get_child(expr, 0), if_macro);
+      op1 = eval_constant(child0, if_macro);
       if (!op1) return 0;
-      else return eval_constant(get_child(expr, 1), if_macro);
+      else return eval_constant(child1, if_macro);
 
     case BAR_BAR:
-      op1 = eval_constant(get_child(expr, 0), if_macro);
+      op1 = eval_constant(child0, if_macro);
       if (op1) return 1;
-      else return eval_constant(get_child(expr, 1), if_macro);
+      else return eval_constant(child1, if_macro);
 
     case '(': // defined operators are represented as fun calls
-      if (if_macro && get_val(get_child(expr, 0)) == DEFINED_ID) {
-        return get_child(expr, 1) == MACRO;
+      if (if_macro && get_val(child0) == DEFINED_ID) {
+        return child1 == MACRO;
       } else {
         fatal_error("unknown function call in constant expressions");
         return 0;

--- a/pnut.c
+++ b/pnut.c
@@ -668,6 +668,7 @@ void get_ch() {
       include_stack = include_stack->next;
       fp = include_stack->fp;
 #ifdef INCLUDE_LINE_NUMBER_ON_ERROR
+      fp_filepath = include_stack->filepath;
       line_number = include_stack->line_number;
       column_number = include_stack->column_number;
 #endif

--- a/pnut.c
+++ b/pnut.c
@@ -2328,7 +2328,7 @@ ast parse_enum() {
         tail = result;
       } else {
         set_child(tail, 2, new_ast3(',', ident, value, 0));
-        tail = get_child(tail, 2);
+        tail = get_child_(',', tail, 2);
       }
 
       if (tok == ',') {
@@ -2410,7 +2410,7 @@ ast parse_struct_or_union(int struct_or_union_tok) {
         tail = result;
       } else {
         set_child(tail, 2, new_ast3(',', ident, type, 0));
-        tail = get_child(tail, 2);
+        tail = get_child_(',', tail, 2);
       }
     }
 
@@ -2564,7 +2564,7 @@ ast parse_definition(int local) {
           tail = result; // Keep track of the last declaration
         } else {
           set_child(tail, 1, new_ast2(',', current_declaration, 0)); // Link the new declaration to the last one
-          tail = get_child(tail, 1); // Update the last declaration
+          tail = get_child_(',', tail, 1); // Update the last declaration
         }
 
         if (tok == ';') {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,6 +21,7 @@ backend=$1; shift
 bootstrap=0
 safe=0
 fast=0
+compile_only=0
 shell="$SHELL" # Use current shell as the default
 pattern=".*"
 while [ $# -gt 0 ]; do
@@ -30,6 +31,7 @@ while [ $# -gt 0 ]; do
     --bootstrap)     bootstrap=1;        shift 1;;
     --safe)          safe=1;             shift 1;;
     --fast)          fast=1;             shift 1;;
+    --compile-only)  compile_only=1;     shift 1;;
     *) echo "Unknown option: $1"; exit 1;;
   esac
 done
@@ -221,6 +223,11 @@ run_test() { # file_to_test: $1
   compile_test "$file" > "$dir/$filename.$ext" 2> "$dir/$filename.err"
 
   if [ $? -eq 0 ]; then # If compilation was successful
+    if [ "$compile_only" -eq 1 ]; then
+      echo "✅ Compiled $file"
+      return 0
+    fi
+
     chmod +x "$dir/$filename.$ext"
     execute_test "$dir/$filename.$ext" "$(test_timeout $file)" "$(test_args $file)" > "$dir/$filename.output" 2> "$dir/$filename.err"
     if [ $? -eq 0 ]; then # If the executable ran successfully

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -19,6 +19,8 @@ fi
 : ${PNUT_OPTIONS:=} # Default to empty options
 backend=$1; shift
 bootstrap=0
+safe=0
+fast=0
 shell="$SHELL" # Use current shell as the default
 pattern=".*"
 while [ $# -gt 0 ]; do
@@ -26,6 +28,8 @@ while [ $# -gt 0 ]; do
     --shell)         shell="$2";         shift 2;;
     --match)         pattern="$2";       shift 2;;
     --bootstrap)     bootstrap=1;        shift 1;;
+    --safe)          safe=1;             shift 1;;
+    --fast)          fast=1;             shift 1;;
     *) echo "Unknown option: $1"; exit 1;;
   esac
 done
@@ -45,6 +49,19 @@ case "$backend" in
     exit 1
     ;;
 esac
+
+if [ "$safe" -eq 1 ]; then
+  # Enable safe mode which checks get_child accesses
+  PNUT_EXE_OPTIONS="$PNUT_EXE_OPTIONS -DSAFE_MODE"
+fi
+
+if [ "$fast" -eq 1 ]; then
+  if [ "$backend" != "sh" ]; then
+    fail "Fast mode is not supported for the sh backend"
+  fi
+  # Enable fast mode which optimizes constant parameters
+  PNUT_EXE_OPTIONS="$PNUT_EXE_OPTIONS -DSH_SAVE_VARS_WITH_SET"
+fi
 
 # Compile pnut, either using gcc or with pnut itself. Set pnut_comp to the compiled pnut executable
 # The compiled pnut executable is cached in the tests folder to speed up the process

--- a/tests/_all/preprocessor/macro/builtin-stubbed.c
+++ b/tests/_all/preprocessor/macro/builtin-stubbed.c
@@ -1,4 +1,5 @@
 // tests for __FILE__, __LINE__, __DATE__, __TIME__, __TIMESTAMP__ built-in macros
+// comp_pnut_opt: -USAFE_MODE
 #include <stdio.h>
 
 #ifndef __FILE__

--- a/tests/_all/preprocessor/macro/builtin.golden
+++ b/tests/_all/preprocessor/macro/builtin.golden
@@ -1,5 +1,5 @@
 tests/_all/preprocessor/macro/builtin-stubbed.c
-41
+42
 Jan  1 1970
 00:00:00
 Jan  1 1970 00:00:00


### PR DESCRIPTION
## Context

Because we must restrict the C features used in pnut, the AST objects are relatively untyped and it's very easy to make mistakes. This became evident when trying to overhaul how declarations are parsed and constructed and I wasn't able to make any progress because too much of the code generators were broken.

## Changes

This PR adds safe object accessors that take the expected node type (parent and child) as input so that when the `SAFE_MODE` option is enabled, accesses can be checked and an error thrown at runtime. When the option is not enabled, the expected node types serve as documentation in the C code but are thrown away during macro expansion, meaning the resulting code doesn't incur the overhead of checking every access.

Most calls to unsafe accessors were changed to safe accessors, which should make changing the AST much easier.