### PR TITLE
Pass error location to expect_tok

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -2267,8 +2267,7 @@ void parse_error_internal(char * msg, int token, char * file, int line) {
   exit(1);
 }
 
-
-void expect_tok(int expected_tok) {
+void expect_tok_(int expected_tok, char* file, int line) {
   if (tok != expected_tok) {
 #ifdef NICE_ERR_MSG
     putstr("expected tok="); print_tok_type(expected_tok);
@@ -2277,10 +2276,12 @@ void expect_tok(int expected_tok) {
     putstr("expected tok="); putint(expected_tok);
     putstr("\ncurrent tok="); putint(tok); putchar('\n');
 #endif
-    parse_error("unexpected token", tok);
+    parse_error_internal("unexpected token", tok, file, line);
   }
   get_tok();
 }
+
+#define expect_tok(expected_tok) expect_tok_(expected_tok, __FILE__, __LINE__)
 
 ast parse_comma_expression();
 ast parse_cast_expression();


### PR DESCRIPTION
That way, the location of the `expect_tok` call in the pnut source code can easily be found.