### PR TITLE
Fix bug where last conditional block of switch would execute as the default

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -196,7 +196,7 @@ void show_ast(char* name, ast obj) {
   int nb_children = get_nb_children(obj);
   if (nb_children == 0) nb_children = 1; // Account for value of ast nodes with no child
   for (i = 0; i < nb_children + 1; i++) {
-    printf("%s[%d] = %d\n", name, i, heap[obj + i]);
+    printf("%s[%d] = %d\n", name, i, (int) heap[obj + i]);
   }
 }
 

--- a/exe.c
+++ b/exe.c
@@ -977,9 +977,10 @@ void codegen_call(ast node) {
   int lbl;
 
   if (binding == 0) {
-    lbl = alloc_label();
-    cgc_add_global_fun(ident_probe, lbl, 0);
-    binding = cgc_globals;
+    putstr("ident = ");
+    putstr(string_pool + probe_string(ident_probe));
+    putchar('\n');
+    fatal_error("codegen_call: function not found");
   }
 
   call(heap[binding+4]);

--- a/exe.c
+++ b/exe.c
@@ -1733,11 +1733,15 @@ void codegen_statement(ast node) {
     lbl2 = alloc_label(); // lbl2: next case
 
     cgc_add_enclosing_switch(cgc_fs, lbl1, lbl2);
+    binding = cgc_locals;
 
     codegen_rvalue(get_child_(SWITCH_KW, node, 0));    // switch operand
-    jump(lbl2);                            // Jump to first case
+    jump(lbl2);                                        // Jump to first case
     codegen_statement(get_child_(SWITCH_KW, node, 1)); // switch body
 
+    // false jump location of last case
+    // Reload because the label is updated when a new case is added
+    lbl2 = heap[binding + 4];
     if (heap[lbl2 + 1] >= 0) {
       def_label(lbl2); // No case statement => jump to end of switch
     }

--- a/exe.c
+++ b/exe.c
@@ -338,16 +338,16 @@ int alloc_label(char* name) {
 
 #define assert_all_labels_defined() // No-op
 #define add_label(lbl) // No-op
+#define alloc_label(name) alloc_label_()
 
-#endif
-
-int alloc_label() {
+int alloc_label_() {
   int lbl = alloc_obj(2);
   heap[lbl] = GENERIC_LABEL;
   heap[lbl + 1] = 0; // Address of label
   add_label(lbl);
   return lbl;
 }
+#endif
 
 int alloc_goto_label() {
   int lbl = alloc_obj(3);
@@ -894,8 +894,8 @@ void codegen_binop(int op, ast lhs, ast rhs) {
 
   if (cond != -1) {
 
-    lbl1 = alloc_label();
-    lbl2 = alloc_label();
+    lbl1 = alloc_label(0);
+    lbl2 = alloc_label(0);
     jump_cond_reg_reg(cond, lbl1, reg_X, reg_Y);
     xor_reg_reg(reg_X, reg_X);
     jump(lbl2);
@@ -1161,7 +1161,7 @@ int codegen_lvalue(ast node) {
 }
 
 void codegen_string(int string_probe) {
-  int lbl = alloc_label();
+  int lbl = alloc_label(0);
   char *string_start = string_pool + heap[string_probe + 1];
   char *string_end = string_start + heap[string_probe + 4];
 
@@ -1370,7 +1370,7 @@ void codegen_rvalue(ast node) {
       write_mem_location(reg_Y, 0, reg_X, left_width);
       push_reg(reg_X);
     } else if (op == AMP_AMP || op == BAR_BAR) {
-      lbl1 = alloc_label();
+      lbl1 = alloc_label(0);
       codegen_rvalue(child0);
       pop_reg(reg_X);
       push_reg(reg_X);
@@ -1432,8 +1432,8 @@ void codegen_rvalue(ast node) {
   } else if (nb_children == 3) {
 
     if (op == '?') {
-      lbl1 = alloc_label(); // false label
-      lbl2 = alloc_label(); // end label
+      lbl1 = alloc_label(0); // false label
+      lbl2 = alloc_label(0); // end label
       codegen_rvalue(child0);
       pop_reg(reg_X);
       grow_fs(-1);
@@ -1461,8 +1461,8 @@ void codegen_rvalue(ast node) {
 
 void codegen_begin() {
 
-  setup_lbl = alloc_label();
-  init_start_lbl = alloc_label();
+  setup_lbl = alloc_label("setup");
+  init_start_lbl = alloc_label("init_start");
   init_next_lbl = init_start_lbl;
 
   // Make room for heap start and malloc bump pointer.
@@ -1476,46 +1476,46 @@ void codegen_begin() {
   void_type = new_ast0(VOID_KW, 0);
   void_star_type = new_ast0(VOID_KW, 1);
 
-  main_lbl = alloc_label();
+  main_lbl = alloc_label("main");
   cgc_add_global_fun(init_ident(IDENTIFIER, "main"), main_lbl, void_type);
 
-  exit_lbl = alloc_label();
+  exit_lbl = alloc_label("exit");
   cgc_add_global_fun(init_ident(IDENTIFIER, "exit"), exit_lbl, void_type);
 
-  getchar_lbl = alloc_label();
+  getchar_lbl = alloc_label("getchar");
   cgc_add_global_fun(init_ident(IDENTIFIER, "getchar"), getchar_lbl, char_type);
 
-  putchar_lbl = alloc_label();
+  putchar_lbl = alloc_label("putchar");
   cgc_add_global_fun(init_ident(IDENTIFIER, "putchar"), putchar_lbl, void_type);
 
-  fopen_lbl = alloc_label();
+  fopen_lbl = alloc_label("fopen");
   cgc_add_global_fun(init_ident(IDENTIFIER, "fopen"), fopen_lbl, int_type);
 
-  fclose_lbl = alloc_label();
+  fclose_lbl = alloc_label("fclose");
   cgc_add_global_fun(init_ident(IDENTIFIER, "fclose"), fclose_lbl, void_type);
 
-  fgetc_lbl = alloc_label();
+  fgetc_lbl = alloc_label("fgetc");
   cgc_add_global_fun(init_ident(IDENTIFIER, "fgetc"), fgetc_lbl, char_type);
 
-  malloc_lbl = alloc_label();
+  malloc_lbl = alloc_label("malloc");
   cgc_add_global_fun(init_ident(IDENTIFIER, "malloc"), malloc_lbl, void_star_type);
 
-  free_lbl = alloc_label();
+  free_lbl = alloc_label("free");
   cgc_add_global_fun(init_ident(IDENTIFIER, "free"), free_lbl, char_type);
 
-  read_lbl = alloc_label();
+  read_lbl = alloc_label("read");
   cgc_add_global_fun(init_ident(IDENTIFIER, "read"), read_lbl, int_type);
 
-  write_lbl = alloc_label();
+  write_lbl = alloc_label("write");
   cgc_add_global_fun(init_ident(IDENTIFIER, "write"), write_lbl, int_type);
 
-  open_lbl = alloc_label();
+  open_lbl = alloc_label("open");
   cgc_add_global_fun(init_ident(IDENTIFIER, "open"), open_lbl, int_type);
 
-  close_lbl = alloc_label();
+  close_lbl = alloc_label("close");
   cgc_add_global_fun(init_ident(IDENTIFIER, "close"), close_lbl, int_type);
 
-  printf_lbl = alloc_label();
+  printf_lbl = alloc_label("printf");
   cgc_add_global_fun(init_ident(IDENTIFIER, "printf"), printf_lbl, void_type);
 
   jump(setup_lbl);
@@ -1596,10 +1596,9 @@ void codegen_glo_var_decl(ast node) {
   if (get_op(type) != '[') { // not array declaration
 
     def_label(init_next_lbl);
-    init_next_lbl = alloc_label();
+    init_next_lbl = alloc_label("init_next");
 
     if (init != 0) {
-
       codegen_rvalue(init);
     } else {
       xor_reg_reg(reg_X, reg_X);
@@ -1683,8 +1682,8 @@ void codegen_statement(ast node) {
 
   if (op == IF_KW) {
 
-    lbl1 = alloc_label(); // else statement
-    lbl2 = alloc_label(); // join point after if
+    lbl1 = alloc_label(0); // else statement
+    lbl2 = alloc_label(0); // join point after if
     codegen_rvalue(get_child_(IF_KW, node, 0));
     pop_reg(reg_X);
     grow_fs(-1);
@@ -1698,8 +1697,8 @@ void codegen_statement(ast node) {
 
   } else if (op == WHILE_KW) {
 
-    lbl1 = alloc_label(); // while statement start
-    lbl2 = alloc_label(); // join point after while
+    lbl1 = alloc_label(0); // while statement start
+    lbl2 = alloc_label(0); // join point after while
 
     save_fs = cgc_fs;
     save_locals = cgc_locals;
@@ -1721,9 +1720,9 @@ void codegen_statement(ast node) {
 
   } else if (op == FOR_KW) {
 
-    lbl1 = alloc_label(); // while statement start
-    lbl2 = alloc_label(); // join point after while
-    lbl3 = alloc_label(); // initial loop starting point
+    lbl1 = alloc_label(0); // while statement start
+    lbl2 = alloc_label(0); // join point after while
+    lbl3 = alloc_label(0); // initial loop starting point
 
     save_fs = cgc_fs;
     save_locals = cgc_locals;
@@ -1749,8 +1748,8 @@ void codegen_statement(ast node) {
 
   } else if (op == DO_KW) {
 
-    lbl1 = alloc_label(); // do statement start
-    lbl2 = alloc_label(); // break point
+    lbl1 = alloc_label(0); // do statement start
+    lbl2 = alloc_label(0); // break point
 
     save_fs = cgc_fs;
     save_locals = cgc_locals;
@@ -1774,8 +1773,8 @@ void codegen_statement(ast node) {
     save_fs = cgc_fs;
     save_locals = cgc_locals;
 
-    lbl1 = alloc_label(); // lbl1: end of switch
-    lbl2 = alloc_label(); // lbl2: next case
+    lbl1 = alloc_label(0); // lbl1: end of switch
+    lbl2 = alloc_label(0); // lbl2: next case
 
     cgc_add_enclosing_switch(cgc_fs, lbl1, lbl2);
     binding = cgc_locals;
@@ -1806,10 +1805,10 @@ void codegen_statement(ast node) {
     binding = cgc_lookup_enclosing_switch(cgc_locals);
 
     if (binding != 0) {
-      lbl1 = alloc_label();                   // skip case when falling through
+      lbl1 = alloc_label(0);                   // skip case when falling through
       jump(lbl1);
       def_label(heap[binding + 4]);           // false jump location of previous case
-      heap[binding + 4] = alloc_label();      // create false jump location for current case
+      heap[binding + 4] = alloc_label(0);     // create false jump location for current case
       dup(reg_X);                             // duplicate switch operand for the comparison
       codegen_rvalue(get_child_(CASE_KW, node, 0)); // evaluate case expression and compare it
       pop_reg(reg_Y); pop_reg(reg_X); grow_fs(-2);
@@ -1827,7 +1826,7 @@ void codegen_statement(ast node) {
 
     if (binding != 0) {
       def_label(heap[binding + 4]);           // false jump location of previous case
-      heap[binding + 4] = alloc_label();      // create label for next case (even if default catches all cases)
+      heap[binding + 4] = alloc_label(0);     // create label for next case (even if default catches all cases)
       codegen_statement(get_child_(DEFAULT_KW, node, 0));  // default statement
     } else {
       fatal_error("default outside of switch");
@@ -1936,7 +1935,7 @@ void codegen_glo_fun_decl(ast node) {
   binding = cgc_lookup_fun(name, cgc_globals);
 
   if (binding == 0) {
-    lbl = alloc_label();
+    lbl = alloc_label(STRING_BUF(name));
     cgc_add_global_fun(name, lbl, fun_type);
     binding = cgc_globals;
   }
@@ -2002,7 +2001,7 @@ void rt_crash(char* msg) {
 }
 
 void rt_malloc() {
-  int end_lbl = alloc_label();
+  int end_lbl = alloc_label("rt_malloc_success");
 
   mov_reg_mem(reg_Y, reg_glo, word_size); // Bump pointer
   add_reg_reg(reg_X, reg_Y);              // New bump pointer
@@ -2029,7 +2028,7 @@ void rt_free() {
 
 void codegen_end() {
 
-  int glo_setup_loop_lbl = alloc_label();
+  int glo_setup_loop_lbl = alloc_label("glo_setup_loop");
 
   def_label(setup_lbl);
 

--- a/exe.c
+++ b/exe.c
@@ -1016,7 +1016,6 @@ void codegen_call(ast node) {
   ast nb_params = codegen_params(params);
 
   int binding = cgc_lookup_fun(ident_probe, cgc_globals);
-  int lbl;
 
   if (binding == 0) {
     putstr("ident = ");

--- a/pnut.c
+++ b/pnut.c
@@ -6,6 +6,11 @@
 #include <string.h>
 #include <stdint.h> // for intptr_t
 
+#ifdef PNUT_CC
+// On pnut, intptr_t is not defined
+#define intptr_t int
+#endif
+
 #define ast int
 #define true 1
 #define false 0
@@ -264,7 +269,7 @@ int hash;
 #define HASH_PARAM 1026
 #define HASH_PRIME 1009
 #define HEAP_SIZE 200000
-int heap[HEAP_SIZE];
+intptr_t heap[HEAP_SIZE];
 int heap_alloc = HASH_PRIME;
 
 int alloc_result;

--- a/sh.c
+++ b/sh.c
@@ -28,10 +28,6 @@ void handle_shell_include() {
 
 #define text int
 #define TEXT_POOL_SIZE 1000000
-#ifdef PNUT_CC
-// On pnut, intptr_t is not defined
-#define intptr_t int
-#endif
 intptr_t text_pool[TEXT_POOL_SIZE];
 int text_alloc = 1; // Start at 1 because 0 is the empty text
 

--- a/tests/_all/six-cc-tests/even-odd.c
+++ b/tests/_all/six-cc-tests/even-odd.c
@@ -1,58 +1,45 @@
-void putnumber(int n) {
-  int acc = 0;
-  int i = 0;
-  int *digits = malloc(10 * sizeof(int)); // Dynamically allocate memory for digits
+#include <stdio.h>
 
-  if (digits == 0) {
-    putstring("Memory allocation failed\n");
-    return;
+void putstr(char *str) {
+  while (*str) {
+    putchar(*str);
+    str += 1;
   }
-
-  if (n == 0) {
-    putchar(48);
-    free(digits); // Free allocated memory
-    return;
-  }
-
-  while (n > 0) {
-    digits[i] = n % 10;
-    n = n / 10;
-    i++;
-  }
-  i--;
-  while (i >= 0) {
-    putchar(digits[i] + 48);
-    i--;
-  }
-
-  free(digits); // Free allocated memory
 }
 
-int abs(int number)
-{
+void putint_aux(int n) {
+  if (n <= -10) putint_aux(n / 10);
+  putchar('0' - (n % 10));
+}
+
+void putint(int n) {
+  if (n < 0) {
+    putchar('-');
+    putint_aux(n);
+  } else {
+    putint_aux(-n);
+  }
+}
+
+int abs(int number);
+int even(int number);
+int odd(int number);
+
+int abs(int number) {
   if(number < 0) return -number;
   return number;
 }
 
-int even(int number)
-{
+int even(int number) {
   int a; /* Local variable so that the function is not simple */
   if(number == 0) return 1;
   return odd(abs(number)-1);
 }
 
-int odd(int number)
-{
+int odd(int number) {
   int a; /* Local variable so that the function is not simple */
   if( number == 0 ) return 0;
   return even(abs(number)-1);
-}
-
-void putstring(char *s) {
-  while (*s) {
-    putchar(*s);
-    s = s + 1;
-  }
 }
 
 int main() {
@@ -60,11 +47,11 @@ int main() {
   int n2;
   n1 = even(10);
   n2 = odd(10);
-  putstring("n1 = ");
-  putnumber(n1);
+  putstr("n1 = ");
+  putint(n1);
   putchar('\n');
-  putstring("n2 = ");
-  putnumber(n2);
+  putstr("n2 = ");
+  putint(n2);
   putchar('\n');
   return 0;
 }

--- a/tests/_all/six-cc-tests/winter-pi2.c
+++ b/tests/_all/six-cc-tests/winter-pi2.c
@@ -18,10 +18,7 @@ int d;
 int c = 0;
 
 int main() {
-  int newline;
-  int newline2;
   int i = 0;
-  newline = identity(10, 2, 3);
 
   while (i < 2800) {
     r[i] = 2000;
@@ -54,11 +51,7 @@ int main() {
     k = k - 14;
   }
 
-  putchar(newline);
+  putchar('\n');
 
   return 0;
-}
-
-int identity(int x, int y, int z) {
-  return x;
 }

--- a/tests/_exe/switch.c
+++ b/tests/_exe/switch.c
@@ -14,61 +14,70 @@ void no_case_switch() {
   }
 }
 
-void basic_switch(){
-  int a = 2;
+void basic_switch() {
+  int a = 0;
 
-  switch (a) {
-    case 1:
-      putchar('A');
-      break;
-    case 2:
-      putchar('B');
-      break;
-    case 3:
-      putchar('C');
-      break;
-    default:
-      putchar('D');
-      break;
+  while (a < 5) {
+    switch (a) {
+      case 1:
+        putchar('A');
+        break;
+      case 2:
+        putchar('B');
+        break;
+      case 3:
+        putchar('C');
+        break;
+      default:
+        putchar('D');
+        break;
+    }
+    a++;
   }
 }
 
-void no_default_break_switch(){
-  int a = 2;
+void no_default_break_switch() {
+  int a = 0;
 
-  switch (a) {
-    case 1:
-      putchar('A');
-      break;
-    case 2:
-      putchar('B');
-      break;
-    case 3:
-      putchar('C');
-      break;
-    default:
-      putchar('D');
-      // break;
+  while (a < 5) {
+    switch (a) {
+      case 1:
+        putchar('A');
+        break;
+      case 2:
+        putchar('B');
+        break;
+      case 3:
+        putchar('C');
+        break;
+      default:
+        putchar('D');
+        // break;
+    }
+    a++;
   }
 }
 
-void no_default_switch(){
-  int a = 2;
+void no_default_switch() {
+  int a = 0;
 
-  switch (a) {
-    case 1:
-      putchar('A');
-      break;
-    case 2:
-      putchar('B');
-      break;
-    case 3:
-      putchar('C');
-      break;
+  while (a < 5) {
+    switch (a) {
+      case 1:
+        putchar('A');
+        break;
+      case 2:
+        putchar('B');
+        break;
+      case 3:
+        putchar('C');
+        break;
+    }
+    a++;
   }
 }
 
-void goto_switch(int a){
+void goto_switch(int a) {
 
   switch (a) {
     case 1:
@@ -91,7 +100,7 @@ void goto_switch(int a){
   putchar('E');
 }
 
-void gotos_switch(){
+void gotos_switch() {
   int a = 0;
 
   start:
@@ -118,7 +127,7 @@ void gotos_switch(){
   putchar('E');
 }
 
-void switch_while(){
+void switch_while() {
   int i = 0;
 
   while (i < 5) {
@@ -198,10 +207,10 @@ void state_machine_switch() {
   switch (state) {
     case 0:
       for (i = 0; i < 10; i++) {
-          state = 1; // Next call will start at case 1
-          putchar('A');
-          return;
-          case 1: putchar('B');
+        state = 1; // Next call will start at case 1
+        putchar('A');
+        return;
+        case 1: putchar('B');
       }
   }
 }

--- a/tests/_exe/switch.golden
+++ b/tests/_exe/switch.golden
@@ -1,8 +1,8 @@
 
 
-B
-B
-B
+DABCD
+DABCD
+ABC
 A
 CE
 ABCE

--- a/x86.c
+++ b/x86.c
@@ -445,7 +445,7 @@ void setup_proc_args(int global_vars_size) {
 #ifdef target_i386_linux
 
 void os_getchar() {
-  int lbl = alloc_label();
+  int lbl = alloc_label("get_char_eof");
   push_reg(BX);           // save address of global variables table
   mov_reg_imm(AX, 0);     // mov  eax, 0
   push_reg(AX);           // push eax      # buffer to read byte
@@ -494,7 +494,7 @@ void os_fclose() {
 }
 
 void os_fgetc() {
-  int lbl = alloc_label();  // label for EOF
+  int lbl = alloc_label("fgetc_eof"); // label for EOF
   push_reg(BX);             // save address of global variables table
   mov_reg_reg(BX, reg_X);   // mov  ebx, file descriptor
   mov_reg_imm(AX, 3);       // mov  eax, 3 == SYS_READ
@@ -600,7 +600,7 @@ void os_close() {
 #ifdef SYSTEM_V_ABI
 
 void os_getchar() {
-  int lbl = alloc_label();
+  int lbl = alloc_label("get_char_eof");
   mov_reg_imm(AX, 0);    // mov  eax, 0
   push_reg(AX);          // push eax      # buffer to read byte
   mov_reg_imm(DI, 0);    // mov  edi, 0   # edi = 0 = STDIN
@@ -641,7 +641,7 @@ void os_fclose() {
 }
 
 void os_fgetc() {
-  int lbl = alloc_label(); // label for EOF
+  int lbl = alloc_label("fgetc_eof"); // label for EOF
   mov_reg_reg(DI, reg_X);  // mov  edi, file descriptor
   mov_reg_imm(AX, 0);      // mov  eax, 0
   push_reg(AX);            // push eax      # buffer to read byte


### PR DESCRIPTION
When a switch statement had no matching case, the last conditional block execute, which caused a very hard to find bug in the pnut-exe bootstrap.