### PR TITLE
Add LIST node type to replace ',' nodes

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -959,17 +959,9 @@ int codegen_params(ast params) {
 
   int fs = 0;
 
-  // Function params are comma expressions that aren't exactly like comma lists.
-  // Comma lists end with a new_ast2(',', last, 0) node, while function params
-  // end with a new_ast2(',', second_last, last) if there are more than one param
-  // and are just the last param if there is only one.
   if (params != 0) {
-    if (get_op(params) == ',') {
-      fs = codegen_params(get_child_(',', params, 1));
-      fs += codegen_param(get_child_(',', params, 0));
-    } else {
-      fs = codegen_param(params);
-    }
+    fs = codegen_params(get_child_opt_(LIST, LIST, params, 1));
+    fs += codegen_param(get_child_(LIST, params, 0));
   }
 
   return fs;

--- a/exe.c
+++ b/exe.c
@@ -537,11 +537,11 @@ ast canonicalize_type(ast type) {
   ast res = type;
   int binding;
 
-  if (get_op(type) == STRUCT_KW && get_child_opt_(STRUCT_KW, ',', type, 2) == 0) { // struct with empty def => reference
+  if (get_op(type) == STRUCT_KW && get_child_opt_(STRUCT_KW, LIST, type, 2) == 0) { // struct with empty def => reference
     binding = cgc_lookup_struct(get_val_(IDENTIFIER, get_child__(STRUCT_KW, IDENTIFIER, type, 1)), cgc_globals);
-  } else if (get_op(type) == UNION_KW && get_child_opt_(UNION_KW, ',', type, 2) == 0) { // union with empty def => reference
+  } else if (get_op(type) == UNION_KW && get_child_opt_(UNION_KW, LIST, type, 2) == 0) { // union with empty def => reference
     binding = cgc_lookup_union(get_val_(IDENTIFIER, get_child__(UNION_KW, IDENTIFIER, type, 1)), cgc_globals);
-  } else if (get_op(type) == ENUM_KW && get_child_opt_(ENUM_KW, ',', type, 2) == 0) { // enum with empty def => reference
+  } else if (get_op(type) == ENUM_KW && get_child_opt_(ENUM_KW, LIST, type, 2) == 0) { // enum with empty def => reference
     binding = cgc_lookup_enum(get_val_(IDENTIFIER, get_child__(ENUM_KW, IDENTIFIER, type, 1)), cgc_globals);
   } else {
     return res;
@@ -566,9 +566,9 @@ int struct_union_size(ast type) {
   type = canonicalize_type(type);
   members = get_child(type, 2);
 
-  while (get_op(members) == ',') {
-    member_type = get_child_(DECL, get_child__(',', DECL, members, 0), 1);
-    members = get_child_opt_(',', ',', members, 1);
+  while (members != 0) {
+    member_type = get_child_(DECL, get_child__(LIST, DECL, members, 0), 1);
+    members = get_child_opt_(LIST, LIST, members, 1);
     member_size = type_width(member_type, true, true);
     sum_size += member_size;                            // Struct size is the sum of its members
     if (member_size > max_size) max_size = member_size; // Union size is the max of its members
@@ -586,7 +586,7 @@ int struct_member_offset_go(ast struct_type, ast member_ident) {
   ast decl, ident;
 
   while (members != 0) {
-    decl = get_child_opt_(',', DECL, members, 0);
+    decl = get_child_opt_(LIST, DECL, members, 0);
     ident = get_child_opt_(DECL, IDENTIFIER, decl, 0);
     if (ident == 0) { // Anonymous struct member, search that struct
       sub_offset = struct_member_offset_go(get_child_(DECL, decl, 1), member_ident);
@@ -601,7 +601,7 @@ int struct_member_offset_go(ast struct_type, ast member_ident) {
       // final offset is not 0.
       offset += round_up_to_word_size(type_width(get_child_(DECL, decl, 1), true, true));
     }
-    members = get_child_opt_(',', ',', members, 1);
+    members = get_child_opt_(LIST, LIST, members, 1);
   }
 
   return -1;
@@ -619,7 +619,7 @@ ast struct_member_go(ast struct_type, ast member_ident) {
   ast decl, ident;
 
   while (members != 0) {
-    decl = get_child_opt_(',', DECL, members, 0);
+    decl = get_child_opt_(LIST, DECL, members, 0);
     ident = get_child_opt_(DECL, IDENTIFIER, decl, 0);
     if (ident == 0) { // Anonymous struct member, search that struct
       ident = struct_member_go(get_child_(DECL, decl, 1), member_ident);
@@ -627,7 +627,7 @@ ast struct_member_go(ast struct_type, ast member_ident) {
     } else if (get_val_(IDENTIFIER, member_ident) == get_val_(IDENTIFIER, ident)) {
       return decl;
     }
-    members = get_child_opt_(',', ',', members, 1);
+    members = get_child_opt_(LIST, LIST, members, 1);
   }
 
   return -1;
@@ -1476,7 +1476,8 @@ void handle_enum_struct_union_type_decl(ast type);
 
 void codegen_enum(ast node) {
   ast name = get_child_opt_(ENUM_KW, IDENTIFIER, node, 1);
-  ast cases = get_child_opt_(ENUM_KW, ',', node, 2);
+  ast cases = get_child_opt_(ENUM_KW, LIST, node, 2);
+  ast cas;
   int binding;
 
   if (name != 0 && cases != 0) { // if enum has a name and members (not a reference to an existing type)
@@ -1485,9 +1486,10 @@ void codegen_enum(ast node) {
     cgc_add_typedef(get_val_(IDENTIFIER, name), BINDING_TYPE_ENUM, node);
   }
 
-  while (get_op(cases) == ',') {
-    cgc_add_enum(get_val_(IDENTIFIER, get_child__(',', IDENTIFIER, cases, 0)), get_child__(',', INTEGER, cases, 1));
-    cases = get_child_opt_(',', ',', cases, 2);
+  while (cases != 0) {
+    cas = get_child_(LIST, cases, 0);
+    cgc_add_enum(get_val_(IDENTIFIER, get_child__('=', IDENTIFIER, cas, 0)), get_child__('=', INTEGER, cas, 1));
+    cases = get_child_opt_(LIST, LIST, cases, 1);
   }
 }
 
@@ -1509,8 +1511,8 @@ void codegen_struct_or_union(ast node, enum BINDING kind) {
   // This is not the right semantic because inner declarations are scoped to
   // this declaration, but it's probably good enough for TCC.
   while (members != 0) {
-    handle_enum_struct_union_type_decl(get_child_(DECL, get_child__(',', DECL, members, 0), 1));
-    members = get_child_opt_(',', ',', members, 1);
+    handle_enum_struct_union_type_decl(get_child_(DECL, get_child__(LIST, DECL, members, 0), 1));
+    members = get_child_opt_(LIST, LIST, members, 1);
   }
 }
 
@@ -1580,9 +1582,9 @@ void codegen_initializer(bool local, ast init, ast type, int base_reg, int offse
           inner_type_width = type_width(get_child_('[', type, 0), true, false);
 
           while (init != 0 && arr_len != 0) {
-            codegen_initializer(local, get_child_(',', init, 0), inner_type, base_reg, offset, true);
+            codegen_initializer(local, get_child_(LIST, init, 0), inner_type, base_reg, offset, true);
             offset += inner_type_width;
-            init = get_child_opt_(',', ',', init, 1);
+            init = get_child_opt_(LIST, LIST, init, 1);
             arr_len -= 1; // decrement the number of elements left to initialize to make sure we don't overflow
           }
 
@@ -1599,38 +1601,38 @@ void codegen_initializer(bool local, ast init, ast type, int base_reg, int offse
         case STRUCT_KW:
           members = get_child_(STRUCT_KW, type, 2);
           while (init != 0 && members != 0) {
-            inner_type = get_child_(DECL, get_child__(',', DECL, members, 0), 1);
-            codegen_initializer(local, get_child_(',', init, 0), inner_type, base_reg, offset, false);
+            inner_type = get_child_(DECL, get_child__(LIST, DECL, members, 0), 1);
+            codegen_initializer(local, get_child_(LIST, init, 0), inner_type, base_reg, offset, false);
             offset += type_width(inner_type, true, true);
-            init = get_child_opt_(',', ',', init, 1);
-            members = get_child_opt_(',', ',', members, 1);
+            init = get_child_opt_(LIST, LIST, init, 1);
+            members = get_child_opt_(LIST, LIST, members, 1);
           }
 
           //  Initialize rest of the members to 0
           while (local && members != 0) {
-            inner_type = get_child_(DECL, get_child__(',', DECL, members, 0), 1);
+            inner_type = get_child_(DECL, get_child__(LIST, DECL, members, 0), 1);
             initialize_memory(0, base_reg, offset, type_width(inner_type, true, true));
             offset += type_width(inner_type, true, true);
-            members = get_child_opt_(',', ',', members, 1);
+            members = get_child_opt_(LIST, LIST, members, 1);
           }
           break;
 
         case UNION_KW:
           members = get_child_(STRUCT_KW, type, 2);
-          if (get_child_opt_(',', ',', init, 1) != 0) {
+          if (get_child_opt_(LIST, LIST, init, 1) != 0) {
             fatal_error("codegen_initializer: union initializer list has more than one element");
           } else if (members == 0) {
             fatal_error("codegen_initializer: union has no members");
           }
-          codegen_initializer(local, get_child_(',', init, 0), get_child_(DECL, get_child__(',', DECL, members, 0), 1), base_reg, offset, false);
+          codegen_initializer(local, get_child_(LIST, init, 0), get_child_(DECL, get_child__(LIST, DECL, members, 0), 1), base_reg, offset, false);
           break;
 
         default:
-          if (get_child_opt_(',', ',', init, 1) != 0 // More than 1 element
-           || get_op(get_child_(',', init, 0)) == INITIALIZER_LIST) { // Or nested initializer list
+          if (get_child_opt_(LIST, LIST, init, 1) != 0 // More than 1 element
+           || get_op(get_child_(LIST, init, 0)) == INITIALIZER_LIST) { // Or nested initializer list
             fatal_error("codegen_initializer: scalar initializer list has more than one element");
           }
-          codegen_rvalue(get_child_(',', init, 0));
+          codegen_rvalue(get_child_(LIST, init, 0));
           pop_reg(reg_X);
           grow_fs(-1);
           write_mem_location(base_reg, offset, reg_X, type_width(type, true, !in_array));
@@ -1669,7 +1671,7 @@ int initializer_size(ast initializer) {
       initializer = get_child_(INITIALIZER_LIST, initializer, 0);
       while (initializer != 0) {
         size += 1;
-        initializer = get_child_opt_(',', ',', initializer, 1);
+        initializer = get_child_opt_(LIST, LIST, initializer, 1);
       }
       return size;
 
@@ -1754,10 +1756,10 @@ void codegen_body(ast node) {
   while (node != 0) {
     stmt = get_child_('{', node, 0);
     if (get_op(stmt) == DECLS) { // Variable declaration
-      declarations = get_child__(DECLS, ',', stmt, 0);
+      declarations = get_child__(DECLS, LIST, stmt, 0);
       while (declarations != 0) { // Multiple variable declarations
-        codegen_local_var_decl(get_child__(',', DECL, declarations, 0));
-        declarations = get_child_opt_(',', ',', declarations, 1);
+        codegen_local_var_decl(get_child__(LIST, DECL, declarations, 0));
+        declarations = get_child_opt_(LIST, LIST, declarations, 1);
       }
     } else {
       codegen_statement(stmt);
@@ -2000,14 +2002,14 @@ void add_params(ast params) {
   int ident;
 
   while (params != 0) {
-    decl = get_child__(',', DECL, params, 0);
+    decl = get_child__(LIST, DECL, params, 0);
     ident = get_val_(IDENTIFIER, get_child__(DECL, IDENTIFIER, decl, 0));
     type = get_child_(DECL, decl, 1);
 
     if (cgc_lookup_var(ident, cgc_locals) != 0) fatal_error("add_params: duplicate parameter");
 
     cgc_add_local_param(ident, type_width(type, false, true) / word_size, type);
-    params = get_child_opt_(',', ',',  params, 1);
+    params = get_child_opt_(LIST, LIST, params, 1);
   }
 }
 
@@ -2016,7 +2018,7 @@ void codegen_glo_fun_decl(ast node) {
   ast body = get_child_opt_(FUN_DECL, '{', node, 1);
   ast name_probe = get_val_(IDENTIFIER, get_child__(DECL, IDENTIFIER, decl, 0));
   ast fun_type = get_child__(DECL, '(', decl, 1);
-  ast params = get_child_opt_('(', ',', fun_type, 1);
+  ast params = get_child_opt_('(', LIST, fun_type, 1);
   ast fun_return_type = get_child_('(', fun_type, 0);
   int binding;
   int save_locals_fun = cgc_locals_fun;
@@ -2052,7 +2054,6 @@ void codegen_glo_fun_decl(ast node) {
 
   ret();
 
-
   cgc_locals_fun = save_locals_fun;
 }
 
@@ -2060,8 +2061,8 @@ void codegen_glo_fun_decl(ast node) {
 // The only thing we need to do is to call handle_enum_struct_union_type_decl
 // on the type specifier, which is the same for all declarations.
 void handle_typedef(ast node) {
-  ast decls = get_child__(TYPEDEF_KW, ',', node, 0);
-  ast decl = get_child__(',', DECL, decls, 0);
+  ast decls = get_child__(TYPEDEF_KW, LIST, node, 0);
+  ast decl = get_child__(LIST, DECL, decls, 0);
   ast type = get_child_(DECL, decl, 1);
 
   handle_enum_struct_union_type_decl(get_type_specifier(type));
@@ -2072,10 +2073,10 @@ void codegen_glo_decl(ast node) {
   int op = get_op(node);
 
   if (op == DECLS) {
-    decls = get_child__(DECLS, ',', node, 0); // Declaration list
+    decls = get_child__(DECLS, LIST, node, 0); // Declaration list
     while (decls != 0) { // Multiple variable declarations
-      codegen_glo_var_decl(get_child__(',', DECL, decls, 0));
-      decls = get_child_opt_(',', ',', decls, 1); // Next variable declaration
+      codegen_glo_var_decl(get_child__(LIST, DECL, decls, 0));
+      decls = get_child_opt_(LIST, LIST, decls, 1); // Next variable declaration
     }
   } else if (op == FUN_DECL) {
     codegen_glo_fun_decl(node);

--- a/exe.c
+++ b/exe.c
@@ -567,8 +567,8 @@ int struct_union_size(ast type) {
   members = get_child(type, 2);
 
   while (members != 0) {
-    member_type = get_child_(DECL, get_child__(LIST, DECL, members, 0), 1);
-    members = get_child_opt_(LIST, LIST, members, 1);
+    member_type = get_child_(DECL, car_(DECL, members), 1);
+    members = tail(members);
     member_size = type_width(member_type, true, true);
     sum_size += member_size;                            // Struct size is the sum of its members
     if (member_size > max_size) max_size = member_size; // Union size is the max of its members
@@ -586,7 +586,7 @@ int struct_member_offset_go(ast struct_type, ast member_ident) {
   ast decl, ident;
 
   while (members != 0) {
-    decl = get_child_opt_(LIST, DECL, members, 0);
+    decl = car_(DECL, members);
     ident = get_child_opt_(DECL, IDENTIFIER, decl, 0);
     if (ident == 0) { // Anonymous struct member, search that struct
       sub_offset = struct_member_offset_go(get_child_(DECL, decl, 1), member_ident);
@@ -601,7 +601,7 @@ int struct_member_offset_go(ast struct_type, ast member_ident) {
       // final offset is not 0.
       offset += round_up_to_word_size(type_width(get_child_(DECL, decl, 1), true, true));
     }
-    members = get_child_opt_(LIST, LIST, members, 1);
+    members = tail(members);
   }
 
   return -1;
@@ -619,7 +619,7 @@ ast struct_member_go(ast struct_type, ast member_ident) {
   ast decl, ident;
 
   while (members != 0) {
-    decl = get_child_opt_(LIST, DECL, members, 0);
+    decl = car_(DECL, members);
     ident = get_child_opt_(DECL, IDENTIFIER, decl, 0);
     if (ident == 0) { // Anonymous struct member, search that struct
       ident = struct_member_go(get_child_(DECL, decl, 1), member_ident);
@@ -627,7 +627,7 @@ ast struct_member_go(ast struct_type, ast member_ident) {
     } else if (get_val_(IDENTIFIER, member_ident) == get_val_(IDENTIFIER, ident)) {
       return decl;
     }
-    members = get_child_opt_(LIST, LIST, members, 1);
+    members = tail(members);
   }
 
   return -1;
@@ -1487,9 +1487,9 @@ void codegen_enum(ast node) {
   }
 
   while (cases != 0) {
-    cas = get_child_(LIST, cases, 0);
+    cas = car_('=', cases);
     cgc_add_enum(get_val_(IDENTIFIER, get_child__('=', IDENTIFIER, cas, 0)), get_child__('=', INTEGER, cas, 1));
-    cases = get_child_opt_(LIST, LIST, cases, 1);
+    cases = tail(cases);
   }
 }
 
@@ -1511,8 +1511,8 @@ void codegen_struct_or_union(ast node, enum BINDING kind) {
   // This is not the right semantic because inner declarations are scoped to
   // this declaration, but it's probably good enough for TCC.
   while (members != 0) {
-    handle_enum_struct_union_type_decl(get_child_(DECL, get_child__(LIST, DECL, members, 0), 1));
-    members = get_child_opt_(LIST, LIST, members, 1);
+    handle_enum_struct_union_type_decl(get_child_(DECL, car_(DECL, members), 1));
+    members = tail(members);
   }
 }
 
@@ -1582,9 +1582,9 @@ void codegen_initializer(bool local, ast init, ast type, int base_reg, int offse
           inner_type_width = type_width(get_child_('[', type, 0), true, false);
 
           while (init != 0 && arr_len != 0) {
-            codegen_initializer(local, get_child_(LIST, init, 0), inner_type, base_reg, offset, true);
+            codegen_initializer(local, car(init), inner_type, base_reg, offset, true);
             offset += inner_type_width;
-            init = get_child_opt_(LIST, LIST, init, 1);
+            init = tail(init);
             arr_len -= 1; // decrement the number of elements left to initialize to make sure we don't overflow
           }
 
@@ -1601,38 +1601,38 @@ void codegen_initializer(bool local, ast init, ast type, int base_reg, int offse
         case STRUCT_KW:
           members = get_child_(STRUCT_KW, type, 2);
           while (init != 0 && members != 0) {
-            inner_type = get_child_(DECL, get_child__(LIST, DECL, members, 0), 1);
-            codegen_initializer(local, get_child_(LIST, init, 0), inner_type, base_reg, offset, false);
+            inner_type = get_child_(DECL, car_(DECL, members), 1);
+            codegen_initializer(local, car(init), inner_type, base_reg, offset, false);
             offset += type_width(inner_type, true, true);
-            init = get_child_opt_(LIST, LIST, init, 1);
-            members = get_child_opt_(LIST, LIST, members, 1);
+            init = tail(init);
+            members = tail(members);
           }
 
           //  Initialize rest of the members to 0
           while (local && members != 0) {
-            inner_type = get_child_(DECL, get_child__(LIST, DECL, members, 0), 1);
+            inner_type = get_child_(DECL, car_(DECL, members), 1);
             initialize_memory(0, base_reg, offset, type_width(inner_type, true, true));
             offset += type_width(inner_type, true, true);
-            members = get_child_opt_(LIST, LIST, members, 1);
+            members = tail(members);
           }
           break;
 
         case UNION_KW:
           members = get_child_(STRUCT_KW, type, 2);
-          if (get_child_opt_(LIST, LIST, init, 1) != 0) {
+          if (tail(init) != 0) {
             fatal_error("codegen_initializer: union initializer list has more than one element");
           } else if (members == 0) {
             fatal_error("codegen_initializer: union has no members");
           }
-          codegen_initializer(local, get_child_(LIST, init, 0), get_child_(DECL, get_child__(LIST, DECL, members, 0), 1), base_reg, offset, false);
+          codegen_initializer(local, car(init), get_child_(DECL, car_(DECL, members), 1), base_reg, offset, false);
           break;
 
         default:
-          if (get_child_opt_(LIST, LIST, init, 1) != 0 // More than 1 element
-           || get_op(get_child_(LIST, init, 0)) == INITIALIZER_LIST) { // Or nested initializer list
+          if (tail(init) != 0 // More than 1 element
+           || get_op(car(init)) == INITIALIZER_LIST) { // Or nested initializer list
             fatal_error("codegen_initializer: scalar initializer list has more than one element");
           }
-          codegen_rvalue(get_child_(LIST, init, 0));
+          codegen_rvalue(car(init));
           pop_reg(reg_X);
           grow_fs(-1);
           write_mem_location(base_reg, offset, reg_X, type_width(type, true, !in_array));
@@ -1671,7 +1671,7 @@ int initializer_size(ast initializer) {
       initializer = get_child_(INITIALIZER_LIST, initializer, 0);
       while (initializer != 0) {
         size += 1;
-        initializer = get_child_opt_(LIST, LIST, initializer, 1);
+        initializer = tail(initializer);
       }
       return size;
 
@@ -1758,8 +1758,8 @@ void codegen_body(ast node) {
     if (get_op(stmt) == DECLS) { // Variable declaration
       declarations = get_child__(DECLS, LIST, stmt, 0);
       while (declarations != 0) { // Multiple variable declarations
-        codegen_local_var_decl(get_child__(LIST, DECL, declarations, 0));
-        declarations = get_child_opt_(LIST, LIST, declarations, 1);
+        codegen_local_var_decl(car_(DECL, declarations));
+        declarations = tail(declarations);
       }
     } else {
       codegen_statement(stmt);
@@ -2002,14 +2002,14 @@ void add_params(ast params) {
   int ident;
 
   while (params != 0) {
-    decl = get_child__(LIST, DECL, params, 0);
+    decl = car_(DECL, params);
     ident = get_val_(IDENTIFIER, get_child__(DECL, IDENTIFIER, decl, 0));
     type = get_child_(DECL, decl, 1);
 
     if (cgc_lookup_var(ident, cgc_locals) != 0) fatal_error("add_params: duplicate parameter");
 
     cgc_add_local_param(ident, type_width(type, false, true) / word_size, type);
-    params = get_child_opt_(LIST, LIST, params, 1);
+    params = tail(params);
   }
 }
 
@@ -2062,7 +2062,7 @@ void codegen_glo_fun_decl(ast node) {
 // on the type specifier, which is the same for all declarations.
 void handle_typedef(ast node) {
   ast decls = get_child__(TYPEDEF_KW, LIST, node, 0);
-  ast decl = get_child__(LIST, DECL, decls, 0);
+  ast decl = car_(DECL, decls);
   ast type = get_child_(DECL, decl, 1);
 
   handle_enum_struct_union_type_decl(get_type_specifier(type));
@@ -2075,8 +2075,8 @@ void codegen_glo_decl(ast node) {
   if (op == DECLS) {
     decls = get_child__(DECLS, LIST, node, 0); // Declaration list
     while (decls != 0) { // Multiple variable declarations
-      codegen_glo_var_decl(get_child__(LIST, DECL, decls, 0));
-      decls = get_child_opt_(LIST, LIST, decls, 1); // Next variable declaration
+      codegen_glo_var_decl(car_(DECL, decls));
+      decls = tail(decls); // Next variable declaration
     }
   } else if (op == FUN_DECL) {
     codegen_glo_fun_decl(node);

--- a/pnut.c
+++ b/pnut.c
@@ -506,6 +506,16 @@ void set_car(int pair, int value)    { return set_child(pair, 0, value); }
 void set_cdr(int pair, int value)    { return set_child(pair, 1, value); }
 #define tail(x) cdr_(LIST, x)
 
+// Returns the only element of a singleton list, if it is a singleton list.
+// Otherwise, returns 0.
+ast list_singleton(ast list) {
+  if (list != 0 && tail(list) == 0) {
+    return car(list);
+  } else {
+    return 0;
+  }
+}
+
 // Simple accessor to get the string from the string pool
 #define STRING_BUF(string_val) (string_pool + heap[string_val+1])
 #define STRING_LEN(string_val) (heap[string_val+4])
@@ -2273,6 +2283,7 @@ void expect_tok_(int expected_tok, char* file, int line) {
 }
 
 ast parse_comma_expression();
+ast parse_call_params();
 ast parse_cast_expression();
 ast parse_compound_statement();
 ast parse_conditional_expression();
@@ -2939,7 +2950,7 @@ ast parse_postfix_expression() {
       if (tok == ')') {
         child = 0;
       } else {
-        child = parse_comma_expression();
+        child = parse_call_params();
       }
       result = new_ast2('(', result, child);
       expect_tok(')');
@@ -3300,6 +3311,18 @@ ast parse_comma_expression() {
     get_tok();
     result = new_ast2(',', result, 0);
     set_child(result, 1, parse_comma_expression());
+  }
+
+  return result;
+}
+
+ast parse_call_params() {
+  ast result = parse_assignment_expression();
+  result = new_ast2(LIST, result, 0);
+
+  if (tok == ',') {
+    get_tok();
+    set_child(result, 1, parse_call_params());
   }
 
   return result;

--- a/pnut.c
+++ b/pnut.c
@@ -202,6 +202,8 @@ enum {
   IDENTIFIER = 500,
   TYPE = 501,
   MACRO = 502,
+
+  LIST = 600, // List object
 };
 
 void putstr(char *str) {
@@ -2379,11 +2381,11 @@ ast parse_enum() {
       }
 
       if (result == 0) {
-        result = new_ast3(',', ident, value, 0);
+        result = new_ast2(LIST, new_ast2('=', ident, value), 0);
         tail = result;
       } else {
-        set_child(tail, 2, new_ast3(',', ident, value, 0));
-        tail = get_child_(',', tail, 2);
+        set_child(tail, 1, new_ast2(LIST, new_ast2('=', ident, value), 0));
+        tail = get_child_(LIST, tail, 1);
       }
 
       if (tok == ',') {
@@ -2436,19 +2438,19 @@ ast parse_struct_or_union(int struct_or_union_tok) {
         decl = new_ast3(DECL, 0, type_specifier, 0);
 
         if (result == 0) {
-          tail = result = new_ast2(',', decl, 0);
+          tail = result = new_ast2(LIST, decl, 0);
         } else {
-          set_child(tail, 1, new_ast2(',', decl, 0));
-          tail = get_child_(',', tail, 1);
+          set_child(tail, 1, new_ast2(LIST, decl, 0));
+          tail = get_child_(LIST, tail, 1);
         }
       } else {
         while (1) {
           decl = parse_declarator(false, type_specifier);
           if (result == 0) {
-            tail = result = new_ast2(',', decl, 0);
+            tail = result = new_ast2(LIST, decl, 0);
           } else {
-            set_child(tail, 1, new_ast2(',', decl, 0));
-            tail = get_child_(',', tail, 1);
+            set_child(tail, 1, new_ast2(LIST, decl, 0));
+            tail = get_child_(LIST, tail, 1);
           }
 
           if (get_child_(DECL, decl, 1) == VOID_KW) parse_error("member with void type not allowed in struct/union", tok);
@@ -2633,10 +2635,10 @@ int parse_param_list() {
     if (tok == ',') get_tok();
 
     if (result == 0) {
-      tail = result = new_ast2(',', decl, 0);
+      tail = result = new_ast2(LIST, decl, 0);
     } else {
-      set_child(tail, 1, new_ast2(',', decl, 0));
-      tail = get_child_(',', tail, 1);
+      set_child(tail, 1, new_ast2(LIST, decl, 0));
+      tail = get_child_(LIST, tail, 1);
     }
   }
 
@@ -2731,10 +2733,10 @@ ast parse_initializer_list() {
     if (tok == '{') fatal_error("nested initializer lists not supported");
 #endif
     if (result == 0) {
-      tail = result = new_ast2(',', parse_initializer(), 0);
+      tail = result = new_ast2(LIST, parse_initializer(), 0);
     } else {
-      set_child(tail, 1, new_ast2(',', parse_initializer(), 0));
-      tail = get_child_(',', tail, 1);
+      set_child(tail, 1, new_ast2(LIST, parse_initializer(), 0));
+      tail = get_child_(LIST, tail, 1);
     }
     if (tok == ',') get_tok();
     else break;
@@ -2794,10 +2796,10 @@ ast parse_fun_def(ast declarator) {
 
   // Check that the parameters are all named since declarator may be abstract
   while (params != 0) {
-    if (get_child_(DECL, get_child__(',', DECL, params, 0), 0) == 0) {
+    if (get_child_(DECL, get_child__(LIST, DECL, params, 0), 0) == 0) {
       parse_error("Parameter name expected", tok);
     }
-    params = get_child_(',', params, 1);
+    params = get_child_(LIST, params, 1);
   }
   if (get_child_(DECL, declarator, 2) != 0) parse_error("Initializer not allowed in function definition", tok);
   return new_ast2(FUN_DECL, declarator, parse_compound_statement());
@@ -2831,15 +2833,15 @@ ast parse_declaration(bool local) {
     return parse_fun_def(declarator);
   }
 
-  declarators = new_ast2(',', declarator, 0); // Wrap the declarators in a list
+  declarators = new_ast2(LIST, declarator, 0); // Wrap the declarators in a list
   tail = declarators;
 
   // Otherwise, this is a variable or declaration
   while (tok != ';') {
     if (tok == ',') {
       get_tok();
-      set_child(tail, 1, new_ast2(',', parse_declarator_and_initializer(type_specifier), 0));
-      tail = get_child__(',', ',', tail, 1);
+      set_child(tail, 1, new_ast2(LIST, parse_declarator_and_initializer(type_specifier), 0));
+      tail = get_child__(LIST, LIST, tail, 1);
     } else {
       parse_error("';' or ',' expected", tok);
     }
@@ -2850,9 +2852,9 @@ ast parse_declaration(bool local) {
   // type table.
   if (get_child(type_specifier, 0) & MK_TYPE_SPECIFIER(TYPEDEF_KW)) {
     type_specifier = declarators; // Save declarators in type_specifier
-    while (get_op(declarators) == ',') {
-      add_typedef(get_child__(',', DECL, declarators, 0));
-      declarators = get_child_opt_(',', ',', declarators, 1);
+    while (declarators != 0) {
+      add_typedef(get_child__(LIST, DECL, declarators, 0));
+      declarators = get_child_opt_(LIST, LIST, declarators, 1);
     }
     result = new_ast1(TYPEDEF_KW, type_specifier);
   } else {

--- a/pnut.c
+++ b/pnut.c
@@ -2789,10 +2789,11 @@ void add_typedef(ast declarator) {
 }
 
 ast parse_fun_def(ast declarator) {
-  ast params = get_child_(DECL, declarator, 1);
+  ast fun_type = get_child__(DECL, '(', declarator, 1);
+  ast params = get_child_('(', fun_type, 1);
 
   // Check that the parameters are all named since declarator may be abstract
-  while (get_op(params) == ',') {
+  while (params != 0) {
     if (get_child_(DECL, get_child__(',', DECL, params, 0), 0) == 0) {
       parse_error("Parameter name expected", tok);
     }

--- a/sh.c
+++ b/sh.c
@@ -516,8 +516,8 @@ void add_var_to_local_env(ast decl, enum BINDING kind) {
 
 void add_fun_params_to_local_env(ast lst) {
   while (lst != 0) {
-    add_var_to_local_env(get_child__(LIST, DECL, lst, 0), BINDING_PARAM_LOCAL);
-    lst = get_child_opt_(LIST, LIST, lst, 1);
+    add_var_to_local_env(car_(DECL, lst), BINDING_PARAM_LOCAL);
+    lst = tail(lst);
   }
 }
 
@@ -566,8 +566,8 @@ void assert_var_decl_is_safe(ast variable, bool local) { // Helper function for 
 
 void check_decls(ast lst) {
   while (lst != 0) {
-    assert_var_decl_is_safe(get_child__(LIST, DECL, lst, 0), true);
-    lst = get_child_opt_(LIST, LIST, lst, 1);
+    assert_var_decl_is_safe(car_(DECL, lst), true);
+    lst = tail(lst);
   }
 }
 
@@ -659,9 +659,9 @@ text let_params(int params) {
 
   while (params != 0) {
     // TODO: Constant param optimization
-    ident = get_child__(DECL, IDENTIFIER, get_child__(LIST, DECL, params, 0), 0);
+    ident = get_child__(DECL, IDENTIFIER, car_(DECL, params), 0);
     res = concatenate_strings_with(res, string_concat4(wrap_str_lit("let "), env_var_with_prefix(ident, false), wrap_char(' '), format_special_var(new_ast0(IDENTIFIER_DOLLAR, params_ix), false)), wrap_str_lit("; "));
-    params = get_child_opt_(LIST, LIST, params, 1);
+    params = tail(params);
     params_ix += 1;
   }
 
@@ -876,8 +876,7 @@ ast handle_fun_call_side_effect(ast node, ast assign_to, bool executes_condition
   // reused after the function call, so resetting the gensym counter.
   gensym_ix = start_gensym_ix;
 
-  sub1 = new_ast2('=', assign_to, node);
-  sub1 = new_ast2(LIST, sub1, 0);
+  sub1 = cons(new_ast2('=', assign_to, node), 0);
   if (executes_conditionally) {
     if (conditional_fun_calls == 0) { conditional_fun_calls = sub1; }
     else { set_child(conditional_fun_calls_tail, 1, sub1); }
@@ -915,7 +914,7 @@ ast handle_side_effects_go(ast node, bool executes_conditionally) {
     } else if (op == STRING) {
       /* We must initialize strings before the expression */
       sub1 = fresh_string_ident(get_val_(STRING, node));
-      literals_inits = new_ast2(LIST, new_ast2('=', sub1, get_val_(STRING, node)), literals_inits);
+      literals_inits = cons(new_ast2('=', sub1, get_val_(STRING, node)), literals_inits);
       return sub1;
     } else {
       printf("op=%d %c", op, op);
@@ -1039,7 +1038,7 @@ int initializer_list_len(ast node) {
   // Each element of the list has size 1 since nested initializers are not allowed
   while (node != 0) {
     res += 1;
-    node = get_child_(LIST, node, 1);
+    node = tail(node);
   }
 
   return res;
@@ -1053,7 +1052,7 @@ text comp_initializer_list(ast initializer_list, int expected_len) {
   runtime_use_initialize = true;
 
   while (initializer_list != 0) {
-    element = get_child_(LIST, initializer_list, 0);
+    element = car(initializer_list);
     switch (get_op(element)) {
       case INTEGER:
         args = concatenate_strings_with(args, wrap_int(-get_val_(INTEGER, element)), wrap_char(' '));
@@ -1071,7 +1070,7 @@ text comp_initializer_list(ast initializer_list, int expected_len) {
         // TODO: Support nested initializers and constant expressions
         fatal_error("comp_initializer: unexpected operator");
     }
-    initializer_list = get_child_opt_(LIST, LIST, initializer_list, 1);
+    initializer_list = tail(initializer_list);
   }
 
   return args;
@@ -1089,12 +1088,12 @@ text with_prefixed_side_effects(ast test_side_effects, text code) {
   ast side_effect;
 
   while (test_side_effects != 0) {
-    side_effect = get_child__(LIST, '=', test_side_effects, 0);
+    side_effect = car_('=', test_side_effects);
     test_side_effects_code =
       string_concat3(test_side_effects_code,
                      comp_fun_call_code(get_child_('=', side_effect, 1), get_child_('=', side_effect, 0)),
                      wrap_str_lit("; "));
-    test_side_effects = get_child_(LIST, test_side_effects, 1);
+    test_side_effects = tail(test_side_effects);
   }
   if (test_side_effects_code != 0) {
     return string_concat4(wrap_str_lit("{ "), test_side_effects_code, code, wrap_str_lit("; }"));
@@ -1353,9 +1352,9 @@ text comp_rvalue(ast node, int context) {
   fun_call_decl_start = glo_decl_ix;
 
   while (literals_inits != 0) {
-    side_effect = get_child__(LIST, '=', literals_inits, 0);
+    side_effect = car_('=', literals_inits);
     comp_defstr(get_child_('=', side_effect, 0), get_child_('=', side_effect, 1), -1);
-    literals_inits = get_child_opt_(LIST, LIST, literals_inits, 1);
+    literals_inits = tail(literals_inits);
   }
 
   // We don't want to call defstr on every iteration, so we only capture fun
@@ -1366,9 +1365,9 @@ text comp_rvalue(ast node, int context) {
     fun_call_decl_start = glo_decl_ix;
 
   while (replaced_fun_calls2 != 0) {
-    side_effect = get_child__(LIST, '=', replaced_fun_calls2, 0);
+    side_effect = car_('=', replaced_fun_calls2);
     comp_fun_call(get_child_('=', side_effect, 1), get_child_('=', side_effect, 0));
-    replaced_fun_calls2 = get_child_opt_(LIST, LIST, replaced_fun_calls2, 1);
+    replaced_fun_calls2 = tail(replaced_fun_calls2);
   }
 
   // When compiling a test, we place the function side effects inline with the condition.
@@ -2020,7 +2019,7 @@ bool comp_return(ast return_value) {
       append_glo_decl(wrap_str_lit("break"));
     }
   } else if (!in_tail_position) {
-    rest_loc_var_fixups = new_ast2(LIST, append_glo_decl_fixup(), rest_loc_var_fixups);
+    rest_loc_var_fixups = cons(append_glo_decl_fixup(), rest_loc_var_fixups);
     append_glo_decl(wrap_str_lit("return"));
   }
 
@@ -2033,7 +2032,7 @@ void comp_var_decls(ast node) {
   node = get_child_opt_(DECLS, LIST, node, 0);
   while (node != 0) {
     // Add to local env and cummulative env, then initialize
-    var_decl = get_child__(LIST, DECL, node, 0);
+    var_decl = car_(DECL, node);
     assert_var_decl_is_safe(var_decl, true);
     add_var_to_local_env(var_decl, BINDING_VAR_LOCAL);
     if (get_child_(DECL, var_decl, 2) != 0) { // Initializer
@@ -2044,7 +2043,7 @@ void comp_var_decls(ast node) {
       comp_assignment(new_ast0(IDENTIFIER, get_child__(DECL, IDENTIFIER, var, 0)), new_ast0(INTEGER, 0));
     }
 #endif
-    node = get_child_opt_(LIST, LIST, node, 1); // Next variable
+    node = tail(node); // Next variable
   }
 }
 
@@ -2165,9 +2164,9 @@ void comp_glo_fun_decl(ast node) {
   if (trailing_txt == 0) {
     // Show the mapping between the function parameters and $1, $2, etc.
     while (params != 0) {
-      var = get_child__(LIST, DECL, params, 0);
+      var = car_(DECL, params);
       trailing_txt = concatenate_strings_with(trailing_txt, string_concat3(wrap_str_pool(probe_string(get_val_(IDENTIFIER, get_child_(DECL, var, 0)))), wrap_str_lit(": $"), wrap_int(params_ix)), wrap_str_lit(", "));
-      params = get_child_opt_(LIST, LIST, params, 1);
+      params = tail(params);
       params_ix += 1;
     }
     if (trailing_txt != 0) trailing_txt = string_concat(wrap_str_lit(" # "), trailing_txt);
@@ -2190,11 +2189,11 @@ void comp_glo_fun_decl(ast node) {
   params = get_child_opt_('(', LIST, fun_type, 1); // Reload params because params is now = 0
   params_ix = 2;
   while (params != 0) {
-    var = get_child__(LIST, DECL, params, 0);
+    var = car_(DECL, params);
     // TODO: Constant param optimization
     // Constant parameters don't need to be initialized
     comp_assignment(get_child_(DECL, var, 0), new_ast0(IDENTIFIER_DOLLAR, params_ix));
-    params = get_child_opt_(LIST, LIST, params, 1);
+    params = tail(params);
     params_ix += 1;
   }
 #endif
@@ -2210,8 +2209,8 @@ void comp_glo_fun_decl(ast node) {
   // So we fixup the calls to save_vars and unsave_vars at the end.
   fixup_glo_decl(save_loc_vars_fixup, save_local_vars());
   while (rest_loc_var_fixups != 0) {
-    fixup_glo_decl(get_child_(LIST, rest_loc_var_fixups, 0), restore_local_vars(params_ix - 1));
-    rest_loc_var_fixups = get_child_opt_(LIST, LIST, rest_loc_var_fixups, 1);
+    fixup_glo_decl(car(rest_loc_var_fixups), restore_local_vars(params_ix - 1));
+    rest_loc_var_fixups = tail(rest_loc_var_fixups);
   }
 
   // functions cannot be empty so we insert ':' if it's empty
@@ -2318,9 +2317,9 @@ void comp_enum_cases(ast ident, ast cases) {
   }
 
   while (cases != 0) {
-    cas = get_child__(LIST, '=', cases, 0);
+    cas = car_('=', cases);
     comp_assignment_constant(env_var(get_child__('=', IDENTIFIER, cas, 0)), get_child_('=', cas, 1));
-    cases = get_child_opt_(LIST, LIST, cases, 1);
+    cases = tail(cases);
   }
 }
 
@@ -2361,7 +2360,8 @@ void comp_struct(ast ident, ast members) {
     append_glo_decl(wrap_str_lit("# Struct member declarations"));
   }
   while (members != 0) {
-    decl = get_child__(LIST, DECL, members, 0);
+    decl = car_(DECL, members);
+    members = tail(members);
     field_type = get_child_(DECL, decl, 1);
     // Arrays and struct value types are not supported for now.
     // When we have type information on the local and global variables, we'll
@@ -2371,7 +2371,6 @@ void comp_struct(ast ident, ast members) {
     }
 
     comp_assignment_constant(struct_member_var(get_child_opt_(DECL, IDENTIFIER, decl, 0)), offset);
-    members = get_child_opt_(LIST, LIST, members, 1);
     set_val(offset, get_val_(INTEGER, offset) - 1);
   }
 
@@ -2399,7 +2398,7 @@ void handle_enum_struct_union_type_decl(ast type) {
 // on the type specifier.
 void handle_typedef(ast node) {
   ast decls = get_child__(TYPEDEF_KW, LIST, node, 0);
-  ast decl = get_child__(LIST, DECL, decls, 0);
+  ast decl = car_(DECL, decls);
   ast type = get_child_(DECL, decl, 1);
 
   handle_enum_struct_union_type_decl(get_type_specifier(type));
@@ -2424,8 +2423,8 @@ void comp_glo_decl(ast node) {
   } else if (op == DECLS) { // Variable declarations
     declarations = get_child__(DECLS, LIST, node, 0);
     while (declarations != 0) { // Multiple variable declarations
-      comp_glo_var_decl(get_child__(LIST, DECL, declarations, 0));
-      declarations = get_child_opt_(LIST, LIST, declarations, 1);
+      comp_glo_var_decl(car_(DECL, declarations));
+      declarations = tail(declarations);
     }
   } else if (op == FUN_DECL) {
     comp_glo_fun_decl(node);

--- a/sh.c
+++ b/sh.c
@@ -516,8 +516,8 @@ void add_var_to_local_env(ast decl, enum BINDING kind) {
 
 void add_fun_params_to_local_env(ast lst) {
   while (lst != 0) {
-    add_var_to_local_env(get_child__(',', DECL, lst, 0), BINDING_PARAM_LOCAL);
-    lst = get_child_opt_(',', ',', lst, 1);
+    add_var_to_local_env(get_child__(LIST, DECL, lst, 0), BINDING_PARAM_LOCAL);
+    lst = get_child_opt_(LIST, LIST, lst, 1);
   }
 }
 
@@ -566,8 +566,8 @@ void assert_var_decl_is_safe(ast variable, bool local) { // Helper function for 
 
 void check_decls(ast lst) {
   while (lst != 0) {
-    assert_var_decl_is_safe(get_child__(',', DECL, lst, 0), true);
-    lst = get_child_(',', lst, 1);
+    assert_var_decl_is_safe(get_child__(LIST, DECL, lst, 0), true);
+    lst = get_child_opt_(LIST, LIST, lst, 1);
   }
 }
 
@@ -659,9 +659,9 @@ text let_params(int params) {
 
   while (params != 0) {
     // TODO: Constant param optimization
-    ident = get_child__(DECL, IDENTIFIER, get_child__(',', DECL, params, 0), 0);
+    ident = get_child__(DECL, IDENTIFIER, get_child__(LIST, DECL, params, 0), 0);
     res = concatenate_strings_with(res, string_concat4(wrap_str_lit("let "), env_var_with_prefix(ident, false), wrap_char(' '), format_special_var(new_ast0(IDENTIFIER_DOLLAR, params_ix), false)), wrap_str_lit("; "));
-    params = get_child_opt_(',', ',', params, 1);
+    params = get_child_opt_(LIST, LIST, params, 1);
     params_ix += 1;
   }
 
@@ -864,7 +864,7 @@ ast handle_fun_call_side_effect(ast node, ast assign_to, bool executes_condition
     sub1 = node;   // For 1 param, the parent node is the fun call node
     // If there are 2 or more params, we traverse the ',' nodes ...
     while (get_op(sub2) == ',') {
-      sub1 = sub2;; // .. and the parent node is the ',' node
+      sub1 = sub2; // .. and the parent node is the ',' node
       set_child(sub1, 0, handle_side_effects_go(get_child_(',', sub2, 0), executes_conditionally));
       sub2 = get_child_(',', sub2, 1);
     }
@@ -877,7 +877,7 @@ ast handle_fun_call_side_effect(ast node, ast assign_to, bool executes_condition
   gensym_ix = start_gensym_ix;
 
   sub1 = new_ast2('=', assign_to, node);
-  sub1 = new_ast2(',', sub1, 0);
+  sub1 = new_ast2(LIST, sub1, 0);
   if (executes_conditionally) {
     if (conditional_fun_calls == 0) { conditional_fun_calls = sub1; }
     else { set_child(conditional_fun_calls_tail, 1, sub1); }
@@ -915,7 +915,7 @@ ast handle_side_effects_go(ast node, bool executes_conditionally) {
     } else if (op == STRING) {
       /* We must initialize strings before the expression */
       sub1 = fresh_string_ident(get_val_(STRING, node));
-      literals_inits = new_ast2(',', new_ast2('=', sub1, get_val_(STRING, node)), literals_inits);
+      literals_inits = new_ast2(LIST, new_ast2('=', sub1, get_val_(STRING, node)), literals_inits);
       return sub1;
     } else {
       printf("op=%d %c", op, op);
@@ -1039,7 +1039,7 @@ int initializer_list_len(ast node) {
   // Each element of the list has size 1 since nested initializers are not allowed
   while (node != 0) {
     res += 1;
-    node = get_child_(',', node, 1);
+    node = get_child_(LIST, node, 1);
   }
 
   return res;
@@ -1053,7 +1053,7 @@ text comp_initializer_list(ast initializer_list, int expected_len) {
   runtime_use_initialize = true;
 
   while (initializer_list != 0) {
-    element = get_child_(',', initializer_list, 0);
+    element = get_child_(LIST, initializer_list, 0);
     switch (get_op(element)) {
       case INTEGER:
         args = concatenate_strings_with(args, wrap_int(-get_val_(INTEGER, element)), wrap_char(' '));
@@ -1071,7 +1071,7 @@ text comp_initializer_list(ast initializer_list, int expected_len) {
         // TODO: Support nested initializers and constant expressions
         fatal_error("comp_initializer: unexpected operator");
     }
-    initializer_list = get_child_opt_(',', ',', initializer_list, 1);
+    initializer_list = get_child_opt_(LIST, LIST, initializer_list, 1);
   }
 
   return args;
@@ -1089,12 +1089,12 @@ text with_prefixed_side_effects(ast test_side_effects, text code) {
   ast side_effect;
 
   while (test_side_effects != 0) {
-    side_effect = get_child__(',', '=', test_side_effects, 0);
+    side_effect = get_child__(LIST, '=', test_side_effects, 0);
     test_side_effects_code =
       string_concat3(test_side_effects_code,
                      comp_fun_call_code(get_child_('=', side_effect, 1), get_child_('=', side_effect, 0)),
                      wrap_str_lit("; "));
-    test_side_effects = get_child_(',', test_side_effects, 1);
+    test_side_effects = get_child_(LIST, test_side_effects, 1);
   }
   if (test_side_effects_code != 0) {
     return string_concat4(wrap_str_lit("{ "), test_side_effects_code, code, wrap_str_lit("; }"));
@@ -1353,9 +1353,9 @@ text comp_rvalue(ast node, int context) {
   fun_call_decl_start = glo_decl_ix;
 
   while (literals_inits != 0) {
-    side_effect = get_child__(',', '=', literals_inits, 0);
+    side_effect = get_child__(LIST, '=', literals_inits, 0);
     comp_defstr(get_child_('=', side_effect, 0), get_child_('=', side_effect, 1), -1);
-    literals_inits = get_child_opt_(',', ',', literals_inits, 1);
+    literals_inits = get_child_opt_(LIST, LIST, literals_inits, 1);
   }
 
   // We don't want to call defstr on every iteration, so we only capture fun
@@ -1366,9 +1366,9 @@ text comp_rvalue(ast node, int context) {
     fun_call_decl_start = glo_decl_ix;
 
   while (replaced_fun_calls2 != 0) {
-    side_effect = get_child__(',', '=', replaced_fun_calls2, 0);
+    side_effect = get_child__(LIST, '=', replaced_fun_calls2, 0);
     comp_fun_call(get_child_('=', side_effect, 1), get_child_('=', side_effect, 0));
-    replaced_fun_calls2 = get_child_opt_(',', ',', replaced_fun_calls2, 1);
+    replaced_fun_calls2 = get_child_opt_(LIST, LIST, replaced_fun_calls2, 1);
   }
 
   // When compiling a test, we place the function side effects inline with the condition.
@@ -2020,7 +2020,7 @@ bool comp_return(ast return_value) {
       append_glo_decl(wrap_str_lit("break"));
     }
   } else if (!in_tail_position) {
-    rest_loc_var_fixups = new_ast2(',', append_glo_decl_fixup(), rest_loc_var_fixups);
+    rest_loc_var_fixups = new_ast2(LIST, append_glo_decl_fixup(), rest_loc_var_fixups);
     append_glo_decl(wrap_str_lit("return"));
   }
 
@@ -2030,10 +2030,10 @@ bool comp_return(ast return_value) {
 void comp_var_decls(ast node) {
   ast var_decl;
 
-  node = get_child_opt_(DECLS, ',', node, 0);
+  node = get_child_opt_(DECLS, LIST, node, 0);
   while (node != 0) {
     // Add to local env and cummulative env, then initialize
-    var_decl = get_child__(',', DECL, node, 0);
+    var_decl = get_child__(LIST, DECL, node, 0);
     assert_var_decl_is_safe(var_decl, true);
     add_var_to_local_env(var_decl, BINDING_VAR_LOCAL);
     if (get_child_(DECL, var_decl, 2) != 0) { // Initializer
@@ -2044,7 +2044,7 @@ void comp_var_decls(ast node) {
       comp_assignment(new_ast0(IDENTIFIER, get_child__(DECL, IDENTIFIER, var, 0)), new_ast0(INTEGER, 0));
     }
 #endif
-    node = get_child_opt_(',', ',', node, 1); // Next variable
+    node = get_child_opt_(LIST, LIST, node, 1); // Next variable
   }
 }
 
@@ -2134,7 +2134,7 @@ void comp_glo_fun_decl(ast node) {
   ast body = get_child_opt_(FUN_DECL, '{', node, 1);
   ast name_probe = get_val_(IDENTIFIER, get_child__(DECL, IDENTIFIER, decl, 0));
   ast fun_type = get_child__(DECL, '(', decl, 1);
-  ast params = get_child_opt_('(', ',', fun_type, 1);
+  ast params = get_child_opt_('(', LIST, fun_type, 1);
   text trailing_txt = 0;
   int params_ix = 2; // Start at 2 because $1 is assigned to the return location
   ast var;
@@ -2165,9 +2165,9 @@ void comp_glo_fun_decl(ast node) {
   if (trailing_txt == 0) {
     // Show the mapping between the function parameters and $1, $2, etc.
     while (params != 0) {
-      var = get_child__(',', DECL, params, 0);
+      var = get_child__(LIST, DECL, params, 0);
       trailing_txt = concatenate_strings_with(trailing_txt, string_concat3(wrap_str_pool(probe_string(get_val_(IDENTIFIER, get_child_(DECL, var, 0)))), wrap_str_lit(": $"), wrap_int(params_ix)), wrap_str_lit(", "));
-      params = get_child_(',', params, 1);
+      params = get_child_opt_(LIST, LIST, params, 1);
       params_ix += 1;
     }
     if (trailing_txt != 0) trailing_txt = string_concat(wrap_str_lit(" # "), trailing_txt);
@@ -2187,14 +2187,14 @@ void comp_glo_fun_decl(ast node) {
 
 #ifndef SH_INITIALIZE_PARAMS_WITH_LET
   // Initialize parameters
-  params = get_child_opt_('(', ',', fun_type, 1); // Reload params because params is now = 0
+  params = get_child_opt_('(', LIST, fun_type, 1); // Reload params because params is now = 0
   params_ix = 2;
   while (params != 0) {
-    var = get_child__(',', DECL, params, 0);
+    var = get_child__(LIST, DECL, params, 0);
     // TODO: Constant param optimization
     // Constant parameters don't need to be initialized
     comp_assignment(get_child_(DECL, var, 0), new_ast0(IDENTIFIER_DOLLAR, params_ix));
-    params = get_child_opt_(',', ',', params, 1);
+    params = get_child_opt_(LIST, LIST, params, 1);
     params_ix += 1;
   }
 #endif
@@ -2210,8 +2210,8 @@ void comp_glo_fun_decl(ast node) {
   // So we fixup the calls to save_vars and unsave_vars at the end.
   fixup_glo_decl(save_loc_vars_fixup, save_local_vars());
   while (rest_loc_var_fixups != 0) {
-    fixup_glo_decl(get_child_(',', rest_loc_var_fixups, 0), restore_local_vars(params_ix - 1));
-    rest_loc_var_fixups = get_child_opt_(',', ',', rest_loc_var_fixups, 1);
+    fixup_glo_decl(get_child_(LIST, rest_loc_var_fixups, 0), restore_local_vars(params_ix - 1));
+    rest_loc_var_fixups = get_child_opt_(LIST, LIST, rest_loc_var_fixups, 1);
   }
 
   // functions cannot be empty so we insert ':' if it's empty
@@ -2310,14 +2310,17 @@ void comp_assignment_constant(text constant_name, ast rhs) {
 // Since anything that's not a local variable is considered global, this makes
 // it easy to implement enums.
 void comp_enum_cases(ast ident, ast cases) {
+  ast cas;
   if (ident != 0) {
     append_glo_decl(string_concat3(wrap_str_lit("# "), wrap_str_pool(probe_string(get_val_(IDENTIFIER, ident))), wrap_str_lit(" enum declaration")));
   } else {
     append_glo_decl(wrap_str_lit("# Enum declaration"));
   }
-  while (get_op(cases) == ',') {
-    comp_assignment_constant(env_var(get_child__(',', IDENTIFIER, cases, 0)), get_child_(',', cases, 1));
-    cases = get_child_opt_(',', ',', cases, 2);
+
+  while (cases != 0) {
+    cas = get_child__(LIST, '=', cases, 0);
+    comp_assignment_constant(env_var(get_child__('=', IDENTIFIER, cas, 0)), get_child_('=', cas, 1));
+    cases = get_child_opt_(LIST, LIST, cases, 1);
   }
 }
 
@@ -2357,8 +2360,8 @@ void comp_struct(ast ident, ast members) {
   } else {
     append_glo_decl(wrap_str_lit("# Struct member declarations"));
   }
-  while (get_op(members) == ',') {
-    decl = get_child__(',', DECL, members, 0);
+  while (members != 0) {
+    decl = get_child__(LIST, DECL, members, 0);
     field_type = get_child_(DECL, decl, 1);
     // Arrays and struct value types are not supported for now.
     // When we have type information on the local and global variables, we'll
@@ -2368,7 +2371,7 @@ void comp_struct(ast ident, ast members) {
     }
 
     comp_assignment_constant(struct_member_var(get_child_opt_(DECL, IDENTIFIER, decl, 0)), offset);
-    members = get_child_opt_(',', ',', members, 1);
+    members = get_child_opt_(LIST, LIST, members, 1);
     set_val(offset, get_val_(INTEGER, offset) - 1);
   }
 
@@ -2395,8 +2398,8 @@ void handle_enum_struct_union_type_decl(ast type) {
 // The only thing we need to do is to call handle_enum_struct_union_type_decl
 // on the type specifier.
 void handle_typedef(ast node) {
-  ast decls = get_child__(TYPEDEF_KW, ',', node, 0);
-  ast decl = get_child__(',', DECL, decls, 0);
+  ast decls = get_child__(TYPEDEF_KW, LIST, node, 0);
+  ast decl = get_child__(LIST, DECL, decls, 0);
   ast type = get_child_(DECL, decl, 1);
 
   handle_enum_struct_union_type_decl(get_type_specifier(type));
@@ -2419,10 +2422,10 @@ void comp_glo_decl(ast node) {
   if (op == '=') { // Assignments
    comp_assignment(get_child_('=', node, 0), get_child_('=', node, 1));
   } else if (op == DECLS) { // Variable declarations
-    declarations = get_child__(DECLS, ',', node, 0);
+    declarations = get_child__(DECLS, LIST, node, 0);
     while (declarations != 0) { // Multiple variable declarations
-      comp_glo_var_decl(get_child__(',', DECL, declarations, 0));
-      declarations = get_child_opt_(',', ',', declarations, 1);
+      comp_glo_var_decl(get_child__(LIST, DECL, declarations, 0));
+      declarations = get_child_opt_(LIST, LIST, declarations, 1);
     }
   } else if (op == FUN_DECL) {
     comp_glo_fun_decl(node);

--- a/sh.c
+++ b/sh.c
@@ -845,7 +845,7 @@ bool contains_side_effects = 0;
 
 ast handle_fun_call_side_effect(ast node, ast assign_to, bool executes_conditionally) {
   int start_gensym_ix = gensym_ix;
-  ast sub1, sub2;
+  ast sub1;
 
   if (assign_to == 0) {
     assign_to = fresh_ident(); // Unique identifier for the function call


### PR DESCRIPTION
## Context

`,` nodes were used to make lists, but that made it confusing since `,` is also used for the comma operator whose nodes had a slightly different shape (the last `,` always contained 2 non-null children).

This PR replaces these `','` nodes with a new kind of nodes only used for lists. This will make it easier in a follow up PR to convert the AST to a s-exp form.