### PR TITLE
Allocate global variables on heap instead of stack in pnut-exe

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -2213,8 +2213,6 @@ void rt_free() {
 
 void codegen_end() {
 
-  int glo_setup_loop_lbl = alloc_label("glo_setup_loop");
-
   def_label(setup_lbl);
 
   // Allocate some space for the global variables.

--- a/pnut.c
+++ b/pnut.c
@@ -262,7 +262,7 @@ int prev_ch = EOF;
 int tok;
 int val;
 
-#define STRING_POOL_SIZE 50000
+#define STRING_POOL_SIZE 500000
 char string_pool[STRING_POOL_SIZE];
 int string_pool_alloc = 0;
 int string_start;
@@ -271,7 +271,7 @@ int hash;
 // These parameters give a perfect hashing of the C keywords
 #define HASH_PARAM 1026
 #define HASH_PRIME 1009
-#define HEAP_SIZE 200000
+#define HEAP_SIZE 2000000
 intptr_t heap[HEAP_SIZE];
 int heap_alloc = HASH_PRIME;
 

--- a/x86.c
+++ b/x86.c
@@ -443,6 +443,8 @@ void setup_proc_args(int global_vars_size) {
   // [esp + 8] : global table start (global_vars_size bytes long)
   // ...
   // For x86-64, it works similarly with [rsp + 0] for argc and [rsp + 8] for argv.
+  //
+  // Note(13/02/2025): Global variables are now allocated in a separate memory region so global_vars_size is 0.
 
   mov_reg_reg(reg_X, SP);
   add_reg_imm(reg_X, global_vars_size + word_size); // compute address of argv


### PR DESCRIPTION
## Context

To compile TCC, we need to increase pnut's string pool and heap size. However, the size of global variables was limited by stack size on pnut-exe, meaning that increasing the size too much would segfault the process. This PR moves the global variables on the heap and increases the size of the string pool and heap by a factor of 10, which should hopefully be enough to compile TCC.

For pnut-sh, global variables are already on the heap which is bounded by the shell's integer size (at least 32 bit signed).