### PR TITLE
Emulate 64-bit integers when parsing numeric literals for 64-bit pnut-exe

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -38,15 +38,26 @@ void emit_i64_le(int n) {
   emit_i32_le(n >> 31);
 }
 
-void emit_word_le(int n) {
-  if (word_size == 4) {
-    emit_i32_le(n);
-  } else if (word_size == 8) {
-    emit_i64_le(n);
+#ifdef SUPPORT_64_BIT_LITERALS
+void emit_i32_le_large_imm(int imm_obj) {
+  if (imm_obj <= 0) {
+    emit_i32_le(-imm_obj);
   } else {
-    fatal_error("emit_word_le: unknown word size");
+    // Check that the number doesn't overflow 64 bits
+    if (heap[imm_obj + 1] != 0) fatal_error("emit_i32_le_large_imm: integer overflow");
+    emit_i32_le(heap[imm_obj]);
   }
 }
+
+void emit_i64_le_large_imm(int imm_obj) {
+  if (imm_obj <= 0) {
+    emit_i64_le(-imm_obj);
+  } else {
+    emit_i32_le(heap[imm_obj]);
+    emit_i32_le(heap[imm_obj + 1]);
+  }
+}
+#endif
 
 void write_i8(int n) {
   putchar(n & 0xff);
@@ -82,7 +93,10 @@ const int reg_Z;
 const int reg_SP;
 const int reg_glo;
 
-void mov_reg_imm(int dst, int imm);
+void mov_reg_imm(int dst, int imm);             // Move 32 bit immediate to register
+#ifdef SUPPORT_64_BIT_LITERALS
+void mov_reg_large_imm(int dst, int large_imm); // Move large immediate to register
+#endif
 void mov_reg_reg(int dst, int src);
 void mov_mem_reg(int base, int offset, int src);
 void mov_mem8_reg(int base, int offset, int src);
@@ -1215,7 +1229,11 @@ void codegen_rvalue(ast node) {
 
   if (nb_children == 0) {
     if (op == INTEGER) {
+#ifdef SUPPORT_64_BIT_LITERALS
+      mov_reg_large_imm(reg_X, get_val_(INTEGER, node));
+#else
       mov_reg_imm(reg_X, -get_val_(INTEGER, node));
+#endif
       push_reg(reg_X);
     } else if (op == CHARACTER) {
       mov_reg_imm(reg_X, get_val_(CHARACTER, node));
@@ -1253,7 +1271,11 @@ void codegen_rvalue(ast node) {
           push_reg(reg_X);
           break;
         case BINDING_ENUM_CST:
+#ifdef SUPPORT_64_BIT_LITERALS
+          mov_reg_large_imm(reg_X, get_val_(INTEGER, heap[binding+3]));
+#else
           mov_reg_imm(reg_X, -get_val_(INTEGER, heap[binding+3]));
+#endif
           push_reg(reg_X);
           break;
 

--- a/pnut.c
+++ b/pnut.c
@@ -94,6 +94,11 @@
 #define PARSE_NUMERIC_LITERAL_WITH_BASE
 #endif
 
+// 64 bit literals are only supported on 64 bit platforms for now
+#if defined(target_x86_64_linux) || defined(target_x86_64_mac)
+#define SUPPORT_64_BIT_LITERALS
+#endif
+
 // Options that turns Pnut into a C preprocessor or some variant of it
 // DEBUG_GETCHAR: Read and print the input character by character.
 // DEBUG_CPP: Run preprocessor like gcc -E. This can be useful for debugging the preprocessor.
@@ -1612,12 +1617,18 @@ void init_pnut_macros() {
 #if defined(sh)
   init_ident(MACRO, "PNUT_SH");
 #elif defined(target_i386_linux)
+  init_ident(MACRO, "PNUT_EXE");
+  init_ident(MACRO, "PNUT_EXE_32");
   init_ident(MACRO, "PNUT_I386");
   init_ident(MACRO, "PNUT_I386_LINUX");
 #elif defined (target_x86_64_linux)
+  init_ident(MACRO, "PNUT_EXE");
+  init_ident(MACRO, "PNUT_EXE_64");
   init_ident(MACRO, "PNUT_X86_64");
   init_ident(MACRO, "PNUT_X86_64_LINUX");
 #elif defined (target_x86_64_mac)
+  init_ident(MACRO, "PNUT_EXE");
+  init_ident(MACRO, "PNUT_EXE_64");
   init_ident(MACRO, "PNUT_X86_64");
   init_ident(MACRO, "PNUT_X86_64_MAC");
 #endif

--- a/pnut.c
+++ b/pnut.c
@@ -119,8 +119,8 @@ struct IncludeStack {
   FILE* fp;
   struct IncludeStack *next;
   char *dirname;  // The base path of the file, used to resolve relative paths
-#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
   char *filepath; // The path of the file, used to print error messages
+#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
   int line_number;
   int column_number;
 #endif
@@ -745,8 +745,8 @@ void get_ch() {
       include_stack2 = include_stack;
       include_stack = include_stack->next;
       fp = include_stack->fp;
-#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
       fp_filepath = include_stack->filepath;
+#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
       line_number = include_stack->line_number;
       column_number = include_stack->column_number;
 #endif
@@ -856,8 +856,8 @@ void include_file(char *file_name, char *relative_to) {
   include_stack2->next = include_stack;
   include_stack2->fp = fp;
   include_stack2->dirname = file_parent_directory(fp_filepath);
-#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
   include_stack2->filepath = fp_filepath;
+#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
   include_stack2->line_number = 1;
   include_stack2->column_number = 0;
   // Save the current file position so we can return to it after the included file is done

--- a/pnut.c
+++ b/pnut.c
@@ -908,10 +908,9 @@ void u64_mul_u32(int *x, int y) {
 
 // x = x + y
 void u64_add_u32(int *x, int y) {
-  int a = x[0]; int b = x[1];
   int lo = x[0] + y;
   // Carry (using signed integers)
-  x[1] += (x[0] < 0 != lo < 0);
+  x[1] += ((x[0] < 0) != (lo < 0));
   x[0] = lo;
 }
 

--- a/sh-runtime.c
+++ b/sh-runtime.c
@@ -636,6 +636,7 @@ DEPENDS_ON(put_pstr)
   putstr("          printf \"%%\"\n");
   putstr("          printf_reset\n");
   putstr("          ;;\n");
+  // TODO: Support %l format specifier
   putstr("        'd'|'i'|'o'|'u'|'x'|'X')\n");
   putstr("          printf \"%${__flags}${__width}${__precision}${__head_char}\" $1\n");
   putstr("          shift\n");

--- a/sh.c
+++ b/sh.c
@@ -1638,7 +1638,15 @@ void handle_printf_call(char *format_str, ast params) {
           break;
 
         // The following options are the same between the shell's printf and C's printf
-        case 'd': case 'i': case 'o': case 'u': case 'x': case 'X':
+        case 'l': case 'd': case 'i': case 'o': case 'u': case 'x': case 'X':
+          if (*format_str == 'l') {
+            while (*format_str == 'l') format_str += 1; // Skip the 'l' for long
+            if (*format_str != 'd' && *format_str != 'i' && *format_str != 'o' && *format_str != 'u' && *format_str != 'x' && *format_str != 'X') {
+              printf("*format_str=%c%c\n", *(format_str - 1), *format_str);
+              fatal_error("Invalid printf format: Unsupported long specifier");
+            }
+          }
+
           if (param == 0) fatal_error("Not enough parameters for printf");
           params_text = concatenate_strings_with(params_text, width_text, wrap_char(' '));     // Add width param if needed
           params_text = concatenate_strings_with(params_text, precision_text, wrap_char(' ')); // Add precision param if needed

--- a/x86.c
+++ b/x86.c
@@ -152,8 +152,33 @@ void mov_reg_imm(int dst, int imm) {
 
   rex_prefix(0, dst);
   emit_i8(0xb8 + (dst & 7));
-  emit_word_le(imm);
+  if (word_size == 4) {
+    emit_i32_le(imm);
+  } else if (word_size == 8) {
+    emit_i64_le(imm);
+  } else {
+    fatal_error("mov_reg_imm: unknown word size");
+  }
 }
+
+#ifdef SUPPORT_64_BIT_LITERALS
+void mov_reg_large_imm(int dst, int large_imm) {
+
+  // MOV dst_reg, large_imm  ;; Move 32 bit or 64 bit immediate value to register
+  // See: https://web.archive.org/web/20240407051903/https://www.felixcloutier.com/x86/mov
+
+  rex_prefix(0, dst);
+  emit_i8(0xb8 + (dst & 7));
+
+  if (word_size == 4) {
+    emit_i32_le_large_imm(large_imm);
+  } else if (word_size == 8) {
+    emit_i64_le_large_imm(large_imm);
+  } else {
+    fatal_error("mov_reg_large_imm: unknown word size");
+  }
+}
+#endif
 
 void add_reg_imm(int dst, int imm) {
 


### PR DESCRIPTION
## Context

While writing tests for https://github.com/udem-dlteam/pnut/pull/153 which adds support for unsigned numbers, I tried using literals such as 0xFFFFFFFF (LONG_MAX) but couldn't because the parser only supported literals up to ± 2^31. A potential solution to this problem could have been to make the val variable larger (long long) but this wouldn't work with pnut-sh since integers in POSIX shells only need to be 32-bit signed.

Instead, this PR adds functions to perform 64-bit arithmetic (addition and multiplication) so that numbers larger than ±2^31 can be parsed.

This PR replaces https://github.com/udem-dlteam/pnut/pull/154.