### PR TITLE
Shorten and optimize let/endlet functions

### DIFF
--- a/examples/compiled/all-chars.sh
+++ b/examples/compiled/all-chars.sh
@@ -18,15 +18,15 @@ _main() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/base64.sh
+++ b/examples/compiled/base64.sh
@@ -231,15 +231,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/cat.sh
+++ b/examples/compiled/cat.sh
@@ -280,15 +280,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/cp.sh
+++ b/examples/compiled/cp.sh
@@ -250,15 +250,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/echo.sh
+++ b/examples/compiled/echo.sh
@@ -71,15 +71,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/fib.sh
+++ b/examples/compiled/fib.sh
@@ -32,15 +32,15 @@ _main() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/non_zero.sh
+++ b/examples/compiled/non_zero.sh
@@ -60,15 +60,15 @@ _getchar() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/print-reverse.sh
+++ b/examples/compiled/print-reverse.sh
@@ -89,15 +89,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/reverse.sh
+++ b/examples/compiled/reverse.sh
@@ -70,15 +70,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/select-file.sh
+++ b/examples/compiled/select-file.sh
@@ -256,15 +256,15 @@ _put_pstr() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/sha256sum.sh
+++ b/examples/compiled/sha256sum.sh
@@ -496,15 +496,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/sum-array.sh
+++ b/examples/compiled/sum-array.sh
@@ -46,15 +46,15 @@ _malloc() { # $2 = object size
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/wc-stdin.sh
+++ b/examples/compiled/wc-stdin.sh
@@ -71,15 +71,15 @@ _getchar() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/wc.sh
+++ b/examples/compiled/wc.sh
@@ -295,15 +295,15 @@ make_argv() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/welcome.sh
+++ b/examples/compiled/welcome.sh
@@ -74,15 +74,15 @@ _put_pstr() {
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/examples/compiled/winterpi.sh
+++ b/examples/compiled/winterpi.sh
@@ -55,15 +55,15 @@ readonly __0__=48
 __=0
 __SP=0
 let() { # $1: variable name, $2: value (optional)
-  : $((__SP += 1)) $((__$__SP=$1)) # Push
-  : $(($1=${2-0}))                 # Init
+  : $((__$((__SP += 1))=$1)) # Push
+  : $(($1=${2-0}))           # Init
 }
 endlet() { # $1: return variable
            # $2...: function local variables
   __ret=$1 # Don't overwrite return value
   : $((__tmp = $__ret))
   while [ $# -ge 2 ]; do
-    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop
+    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop
     shift;
   done
   : $(($__ret=__tmp))   # Restore return value

--- a/sh-runtime.c
+++ b/sh-runtime.c
@@ -87,18 +87,18 @@ DEFINE_RUNTIME_FUN(local_vars)
   putstr("__SP=0\n");
 #ifdef SH_INITIALIZE_PARAMS_WITH_LET
   putstr("let() { # $1: variable name, $2: value (optional)\n");
-  putstr("  : $((__SP += 1)) $((__$__SP=$1)) # Push\n");
-  putstr("  : $(($1=${2-0}))                 # Init\n");
+  putstr("  : $((__$((__SP += 1))=$1)) # Push\n");
+  putstr("  : $(($1=${2-0}))           # Init\n");
   putstr("}\n");
 #else
-  putstr("let() { : $((__SP += 1)) $((__$__SP=$1)); }\n");
+  putstr("let() { : $((__$((__SP += 1))=$1)); }\n");
 #endif
   putstr("endlet() { # $1: return variable\n");
   putstr("           # $2...: function local variables\n");
   putstr("  __ret=$1 # Don't overwrite return value\n");
   putstr("  : $((__tmp = $__ret))\n");
   putstr("  while [ $# -ge 2 ]; do\n");
-  putstr("    : $(($2 = __$__SP)) $((__SP -= 1)); # Pop\n");
+  putstr("    : $(($2 = __$(((__SP -= 1) + 1)))) # Pop\n");
   putstr("    shift;\n");
   putstr("  done\n");
   putstr("  : $(($__ret=__tmp))   # Restore return value\n");


### PR DESCRIPTION
## Context

The `let` and `endlet` functions are one of the most called functions in scripts generated by pnut. I noticed that the increment operation could be inlined in the push operation, which should be faster as each reference to a shell variable is an environment lookup which can be expensive on certain shells. The same optimization can be done for the pop operation in `endlet`.

## Benchmarks

Because zsh is so slow, I benchmarked `pnut-sh.sh` compiling `examples/sha256sum.c`.

```
Benchmark 1: dash ./build/pnut-sh.sh examples/sha256sum.c > out
  Time (mean ± σ):      1.913 s ±  0.032 s    [User: 1.707 s, System: 0.199 s]
  Range (min … max):    1.875 s …  1.963 s    10 runs
 
Benchmark 2: dash ./build/pnut-sh-fast.sh examples/sha256sum.c > out
  Time (mean ± σ):      1.872 s ±  0.021 s    [User: 1.671 s, System: 0.197 s]
  Range (min … max):    1.841 s …  1.908 s    10 runs
 
Result: 1.02 ± 0.02 times faster

Benchmark 1: ksh ./build/pnut-sh.sh examples/sha256sum.c > out
  Time (mean ± σ):      1.259 s ±  0.010 s    [User: 1.237 s, System: 0.019 s]
  Range (min … max):    1.251 s …  1.282 s    10 runs
 
Benchmark 2: ksh ./build/pnut-sh-fast.sh examples/sha256sum.c > out
  Time (mean ± σ):      1.251 s ±  0.014 s    [User: 1.225 s, System: 0.020 s]
  Range (min … max):    1.239 s …  1.280 s    10 runs
 
Result: 1.01 ± 0.01 times faster

Benchmark 1: yash ./build/pnut-sh.sh examples/sha256sum.c > out
  Time (mean ± σ):      8.229 s ±  0.099 s    [User: 4.993 s, System: 3.219 s]
  Range (min … max):    8.084 s …  8.377 s    10 runs
 
Benchmark 2: yash ./build/pnut-sh-fast.sh examples/sha256sum.c > out
  Time (mean ± σ):      8.064 s ±  0.090 s    [User: 4.820 s, System: 3.226 s]
  Range (min … max):    7.912 s …  8.216 s    10 runs
 
Result: 1.02 ± 0.02 times faster

Benchmark 1: bash ./build/pnut-sh.sh examples/sha256sum.c > out
  Time (mean ± σ):      4.235 s ±  0.042 s    [User: 4.186 s, System: 0.044 s]
  Range (min … max):    4.188 s …  4.291 s    10 runs
 
Benchmark 2: bash ./build/pnut-sh-fast.sh examples/sha256sum.c > out
  Time (mean ± σ):      4.252 s ±  0.072 s    [User: 4.192 s, System: 0.047 s]
  Range (min … max):    4.172 s …  4.408 s    10 runs
 
Result: 1.00 ± 0.02 times faster

Benchmark 1: zsh ./build/pnut-sh.sh examples/sha256sum.c > out
  Time (mean ± σ):     13.102 s ±  0.133 s    [User: 12.551 s, System: 0.505 s]
  Range (min … max):   12.925 s … 13.337 s    10 runs
 
Benchmark 2: zsh ./build/pnut-sh-fast.sh examples/sha256sum.c > out
  Time (mean ± σ):     13.114 s ±  0.155 s    [User: 12.566 s, System: 0.499 s]
  Range (min … max):   12.923 s … 13.345 s    10 runs
 
Result: 1.00 ± 0.02 times faster
```