### PR TITLE
Fix expect_failure check in run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -151,7 +151,7 @@ test_expect_failure_for_shells() {
 # Pnut has a bug that causes it to miscompile when a certain feature is used.
 # // expect_failure
 test_expect_failure() {
-  if grep -q "// expect_failure" "$1"; then
+  if grep -q "// expect_failure$" "$1"; then
     return 0
   else
     return 1

--- a/tests/_sh/input-output/read-all-chars.c
+++ b/tests/_sh/input-output/read-all-chars.c
@@ -3,7 +3,7 @@
 // This test is not essential for the bootstrap, but since we'd like to use pnut
 // in other contexts, we want to make sure it can handle all characters.
 // For bash 2.05a, the character 1 is not read properly. Assuming all version 2.0* of bash are affected.
-// expect_failure_for: bash-2.0*
+// expect_failure_for: bash-2.0.*
 // Yash's IO is a little bit weird and it's not a very popular shell, disabling the test for now.
 // expect_failure_for: yash
 


### PR DESCRIPTION
## Context

A few weeks ago, a new test annotation was added for tests that are broken but that we still want to run `// expect_failure` test annotation used to disable tests. The check used grep to see if any line contained `// expect_failure`, but it also matched on the `// expect_failure_for:` annotation used to disable tests for specific shells.