### PR TITLE
Fix SH_INCLUDE_C_CODE option

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -1532,6 +1532,9 @@ void handle_preprocessor_directive() {
 
 #ifdef SH_INCLUDE_C_CODE
   code_char_buf_ix = prev_char_buf_ix - 1;
+  // Copy the current char and a newline, because they were consumed by the last get_tok call
+  code_char_buf[code_char_buf_ix++] = '\n';
+  code_char_buf[code_char_buf_ix++] = ch;
 #endif
 }
 

--- a/pnut.c
+++ b/pnut.c
@@ -711,14 +711,14 @@ void pop_if_macro_mask() {
 
 // Includes the preprocessed C code along with the generated shell code
 #ifdef SH_INCLUDE_C_CODE
-#define DECLARATION_BUF_LEN 20000
+#define C_CODE_BUF_LEN 20000
 
-char declaration_char_buf[DECLARATION_BUF_LEN];
-int declaration_char_buf_ix = 0;
-// Point to the last character of the last token.
+char code_char_buf[C_CODE_BUF_LEN];
+int code_char_buf_ix = 0;
+// Point to the **last** character of the **last** token.
 // This is used to skip the current token when printing the code of a
 // declaration since it belongs to the next declaration.
-int last_tok_char_buf_ix = 0;
+int last_tok_code_buf_ix = 0;
 
 void output_declaration_c_code(bool no_header) {
 
@@ -731,19 +731,19 @@ void output_declaration_c_code(bool no_header) {
   putchar(' ');
 
   // Skip leading newlines if any.
-  while (declaration_char_buf[i] == '\n') i += 1;
+  while (code_char_buf[i] == '\n') i += 1;
 
-  for (; i < last_tok_char_buf_ix; i += 1) {
+  for (; i < last_tok_code_buf_ix; i += 1) {
 
-    if (declaration_char_buf[i] == '\n') {
+    if (code_char_buf[i] == '\n') {
       // Condense the C code by removing extra newlines
-      if (declaration_char_buf[i - 1] != declaration_char_buf[i]) {
+      if (code_char_buf[i - 1] != code_char_buf[i]) {
         putchar('\n');
         putchar('#');
         putchar(' ');
       }
     } else {
-      putchar(declaration_char_buf[i]);
+      putchar(code_char_buf[i]);
     }
   }
 
@@ -754,11 +754,11 @@ void output_declaration_c_code(bool no_header) {
   }
 
   // Copy the last token characters to the beginning of the buffer
-  for (i = 0; i < declaration_char_buf_ix - last_tok_char_buf_ix; i += 1) {
-    declaration_char_buf[i] = declaration_char_buf[last_tok_char_buf_ix + i];
+  for (i = 0; i < code_char_buf_ix - last_tok_code_buf_ix; i += 1) {
+    code_char_buf[i] = code_char_buf[last_tok_code_buf_ix + i];
   }
 
-  declaration_char_buf_ix = i;
+  code_char_buf_ix = i;
 }
 #endif
 
@@ -830,8 +830,8 @@ void get_ch() {
 #endif
 #ifdef SH_INCLUDE_C_CODE
   // Save C code chars so they can be displayed with the shell code
-  declaration_char_buf[declaration_char_buf_ix] = ch;
-  declaration_char_buf_ix += 1;
+  code_char_buf[code_char_buf_ix] = ch;
+  code_char_buf_ix += 1;
 #endif
 #ifdef DEBUG_EXPAND_INCLUDES
   // Because ch is always 1 character ahead of the token, we print the character
@@ -1423,7 +1423,7 @@ void handle_shell_include();
 void handle_preprocessor_directive() {
   int temp;
 #ifdef SH_INCLUDE_C_CODE
-  int prev_char_buf_ix = declaration_char_buf_ix;
+  int prev_char_buf_ix = code_char_buf_ix; // Index of the # token in the code buffer
 #endif
   get_tok_macro(); // Get the # token
   get_tok_macro(); // Get the directive
@@ -1518,7 +1518,6 @@ void handle_preprocessor_directive() {
   if (tok != '\n' && tok != EOF) {
     putstr("tok="); putint(tok); putchar('\n');
     putstr("directive="); putint(tok); putchar('\n');
-    putstr("string="); putstr(STRING_BUF(val)); putchar('\n');
     if (tok == IDENTIFIER || tok == MACRO) {
       putstr("string = ");
       putstr(STRING_BUF(val));
@@ -1532,7 +1531,7 @@ void handle_preprocessor_directive() {
   // get_tok before returning.
 
 #ifdef SH_INCLUDE_C_CODE
-  declaration_char_buf_ix = prev_char_buf_ix - 1; // - 1 to undo the #
+  code_char_buf_ix = prev_char_buf_ix - 1;
 #endif
 }
 
@@ -1993,11 +1992,11 @@ void paste_tokens(int left_tok, int left_val) {
 void get_tok() {
 
 #ifdef SH_INCLUDE_C_CODE
-  int prev_char_buf_ix = declaration_char_buf_ix;
+  int prev_char_buf_ix = code_char_buf_ix;
   // Save the cursor in a local variable so we can restore it when the token is
-  // masked off. Not using the last_tok_char_buf_ix global because get_tok can
+  // masked off. Not using the last_tok_code_buf_ix global because get_tok can
   // be called recursively by handle_preprocessor_directive.
-  int prev_last_tok_char_buf_ix = declaration_char_buf_ix;
+  int prev_last_tok_char_buf_ix = code_char_buf_ix;
 #endif
 
 #ifdef INCLUDE_LINE_NUMBER_ON_ERROR
@@ -2008,7 +2007,7 @@ void get_tok() {
   // This outer loop is used to skip over tokens removed by #ifdef/#ifndef/#else
   do {
 #ifdef SH_INCLUDE_C_CODE
-    declaration_char_buf_ix = prev_char_buf_ix; // Skip over tokens that are masked off
+    code_char_buf_ix = prev_char_buf_ix; // Skip over tokens that are masked off
 #endif
 
     while (1) {
@@ -2433,7 +2432,7 @@ void get_tok() {
   } while (!if_macro_mask);
 
 #ifdef SH_INCLUDE_C_CODE
-  last_tok_char_buf_ix = prev_last_tok_char_buf_ix - 1;
+  last_tok_code_buf_ix = prev_last_tok_char_buf_ix - 1;
 #endif
 
 #ifdef INCLUDE_LINE_NUMBER_ON_ERROR


### PR DESCRIPTION
## Context

When using the `SH_INCLUDE_C_CODE` option, the first declaration following a preprocessor directive was missing its first character. This PR fixes this bug.

### Example

```C
#include <iostream>

int a = 5;
int b;

#define A
#ifdef A
int a = 5;
#endif
```

was compiled to:

```shell
# nt a = 5;
_a=5
# int b;
_b=0
# nt a = 5;
_a=5
```

but is now compiled to:

```shell
# int a = 5;
_a=5
# int b;
_b=0
# int a = 5;
_a=5
```

## Other improvements

Comments are attributed to whatever token follows, which causes comments to be dropped or misplaced. I've tried multiple times to find a good way to attribute comments to the relevant token, and I think the following rules are a good approximation for how we read comments:
- if a comment is on its own line, it's about the next line.
- if a comment is trailing a line, it's about the line it trails.

### Example

For the following code,

```C
struct IncludeStack {
  FILE* fp;
  struct IncludeStack *next;
  char *dirname;  // The base path of the file, used to resolve relative paths
  char *filepath; // The path of the file, used to print error messages
#ifdef INCLUDE_LINE_NUMBER_ON_ERROR
  int line_number;
  int column_number;
#endif
};
struct IncludeStack *include_stack, *include_stack2;
FILE *fp = 0; // Current file pointer that's being read
char* fp_filepath = 0; // The path of the current file being read
char* include_search_path = 0; // Search path for include files
```

this source code annotation is produced:

```shell
#################################### C code ####################################
# struct IncludeStack {
#   FILE* fp;
#   struct IncludeStack *next;
#   char *dirname;  // The base path of the file, used to resolve relative paths
#   char *filepath; 
# };
################################# End of C code ################################
# IncludeStack struct member declarations
readonly __fp=0
readonly __next=1
readonly __dirname=2
readonly __filepath=3
readonly __sizeof__IncludeStack=4
# struct IncludeStack *include_stack, *include_stack2;
_include_stack=0
_include_stack2=0
# FILE *fp = 0;
_fp=0
#  // Current file pointer that's being read
# char* fp_filepath = 0;
_fp_filepath=0
#  // The path of the current file being read
# char* include_search_path = 0;
_include_search_path=0
#################################### C code ####################################
#  // Search path for include files
... 
```

We can see that the comment on `filepath` is removed as it's associated with the `ifdef` following it which is removed from the output, and comments trailing the `fp/fp_filepath/include_search_path` declarations appear offset from the rest of the declaration.