### PR TITLE
Fix anonymous struct member lookup

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -672,7 +672,7 @@ ast struct_member_go(ast struct_type, ast member_ident) {
     ident = get_child_opt_(DECL, IDENTIFIER, decl, 0);
     if (ident == 0) { // Anonymous struct member, search that struct
       ident = struct_member_go(get_child_(DECL, decl, 1), member_ident);
-      if (ident != 0) return ident; // Found member in the anonymous struct
+      if (ident != -1) return ident; // Found member in the anonymous struct
     } else if (get_val_(IDENTIFIER, member_ident) == get_val_(IDENTIFIER, ident)) {
       return decl;
     }

--- a/tests/_exe/struct.c
+++ b/tests/_exe/struct.c
@@ -79,6 +79,15 @@ struct NonPowerOf2Struct {
   int val3;
 };
 
+// Linked symbol table
+typedef struct Sym {
+  int tag; // symbol tag
+  struct {
+    int *val; // value
+  };
+  struct Sym *next; // next symbol
+} Sym;
+
 void f(enum Direction dir, Direction dir2) {
   putstr("Direction: "); putint(dir); putstr(" "); putint(dir2); putchar('\n');
 }
@@ -389,4 +398,9 @@ void main() {
   test_nested_structs();
   test_passing_as_value();
   test_casts();
+
+  // Regression test for accessing fields inside anonymous struct/unions
+  Sym *s = (Sym*) malloc(sizeof(Sym));
+  s->tag = 123;
+  s->next = s; // Self-referencing struct
 }


### PR DESCRIPTION
## Context

When searching inside an anonymous structure, `struct_member_go` returns -1 if the field is not found. However, when calling itself recursively, it checked that the result was `!= 0` instead of `!= -1` and so it would return -1 thinking it's the address of the member that was being searched.