### PR TITLE
WIP: Optimize exe size

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -226,6 +226,7 @@ void mov_reg_mem64(int dst, int base, int offset);
 #endif
 
 void add_reg_imm(int dst, int imm);
+void sub_reg_imm(int dst, int imm);
 void add_reg_lbl(int dst, int lbl);
 void add_reg_reg(int dst, int src);
 void or_reg_reg (int dst, int src);

--- a/x86.c
+++ b/x86.c
@@ -205,7 +205,15 @@ void xor_reg_reg(const int dst, const int src) {
   // XOR dst_reg, src_reg ;; dst_reg = dst_reg ^ src_reg
   // See: https://web.archive.org/web/20240323052259/https://www.felixcloutier.com/x86/xor
 
+#if WORD_SIZE == 8
+  if (src == dst) {
+    op_reg_reg(0x31, dst, src, 4); // Use 32-bit opcode for XOR dst_reg, dst_reg because it's shorter
+  } else {
+    op_reg_reg(0x31, dst, src, WORD_SIZE);
+  }
+#else
   op_reg_reg(0x31, dst, src, WORD_SIZE);
+#endif
 }
 
 void cmp_reg_reg(const int dst, const int src) {

--- a/x86.c
+++ b/x86.c
@@ -230,7 +230,8 @@ void mov_reg_reg(const int dst, const int src) {
   // MOV dst_reg, src_reg  ;; dst_reg = src_reg
   // See: https://web.archive.org/web/20240407051903/https://www.felixcloutier.com/x86/mov
 
-  op_reg_reg(0x89, dst, src, WORD_SIZE);
+  // No need to move if src and dst are the same
+  if (dst != src) op_reg_reg(0x89, dst, src, WORD_SIZE);
 }
 
 void mov_reg_imm(const int dst, const int imm) {


### PR DESCRIPTION
**Making this PR to see if it reduces the execution time of dash and zsh, it may or may not be merged.**

## Context

On certain shells, scripts slow down the more variables there are in the environment. This is generally caused by the data structure storing the environment not being adapted to contain this many variables (i.e. dash's 37 entry hash table), and can make the execution time quadratic even when algorithms are linear, as each variable lookup takes a linear time. This means small memory reductions can significantly reduce execution time, as demonstrated in https://github.com/udem-dlteam/pnut/pull/77.

This PR optimizes the instruction encoding to use more compact encoding of common instructions:

- Using 8-bit displacement for memory operands when possible
- Zeroing out a register with xor is done on 32-bit registers since 32-bit operations clear the upper 32-bits of the 64-bit registers.
- Encode immediates as bytes (most literals are small) or sign-extended 32-bit literals.
- Remove redundant mov operations

This PR doesn't touch the exe code generator, where a lot more optimizations are possible but would increase code complexity. 

### Results

Methodology:
 
```shell
> ./bootstrap-pnut-exe.sh --backend <backend>
> wc --bytes build/pnut-x86-by-pnut-x86-by-gcc.exe
```


| Backend       | Size before   | Size after    | pnut-sh.sh pnut-exe.c | pnut-exe.sh pnut-exe.c |
| ------------- | ------------- | ------------- | --------------------- | ---------------------- |
| i386_linux    | 180826        | 146726        | TODO                  | TODO                   |
| x86_64_linux  | 243114        | 178599        | TODO                  | TODO                   |


## Other possible memory optimizations

The `code` buffer stores bytes of machine code but has `int[]` as its type. Using the full 32 bits of ints could cut by 4 the number of environment variables used to store machine code, but labels rely on the extra space to store metadata that's used to resolve addresses that are not yet known.