### PR TITLE
Add -o and extend -D command line options

### DIFF
--- a/bootstrap-pnut-exe.sh
+++ b/bootstrap-pnut-exe.sh
@@ -27,7 +27,7 @@ bootstrap_with_gcc() {
 
   gcc -o $TEMP_DIR/pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c
   # gcc -E -P -DPNUT_CC $PNUT_EXE_OPTIONS pnut.c > "$TEMP_DIR/pnut-after-cpp.c"
-  ./$TEMP_DIR/pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c > $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe || {
+  ./$TEMP_DIR/pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c -o $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe || {
     echo "Failed to compile pnut-x86-by-pnut-x86-by-gcc.exe"
     tail -n 20 $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe
     exit 1
@@ -36,7 +36,7 @@ bootstrap_with_gcc() {
   chmod +x $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe
 
   printf_timing "pnut-x86-by-gcc.exe compiling pnut.c -> pnut-x86-by-pnut-x86-by-gcc.exe" \
-                "./$TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c > $TEMP_DIR/pnut-x86-by-pnut-x86-by-pnut-x86-by-gcc.exe"
+                "./$TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe $PNUT_EXE_OPTIONS pnut.c -o $TEMP_DIR/pnut-x86-by-pnut-x86-by-pnut-x86-by-gcc.exe"
 
   if [ -s $TEMP_DIR/pnut-x86-by-pnut-x86-by-pnut-x86-by-gcc.exe ] ; then
     if diff $TEMP_DIR/pnut-x86-by-pnut-x86-by-gcc.exe $TEMP_DIR/pnut-x86-by-pnut-x86-by-pnut-x86-by-gcc.exe 2>&1 > /dev/null ; then
@@ -72,12 +72,12 @@ bootstrap_with_shell() {
   printf_timing "pnut-sh.sh compiling pnut.c -> pnut-exe-compiled-by-pnut-sh-sh.sh" \
                 "$1 $TEMP_DIR/pnut-sh.sh $PNUT_EXE_OPTIONS pnut.c > $TEMP_DIR/pnut-exe-compiled-by-pnut-sh-sh.sh"
   printf_timing "pnut-exe-compiled-by-pnut-sh-sh.sh compiling pnut.c -> pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe" \
-                "$1 $TEMP_DIR/pnut-exe-compiled-by-pnut-sh-sh.sh $PNUT_EXE_OPTIONS pnut.c > $TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe"
+                "$1 $TEMP_DIR/pnut-exe-compiled-by-pnut-sh-sh.sh $PNUT_EXE_OPTIONS pnut.c -o $TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe"
 
   chmod +x $TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe
 
   printf_timing "pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe compiling pnut.c -> pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe" \
-                "./$TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe $PNUT_EXE_OPTIONS pnut.c > $TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe"
+                "./$TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe $PNUT_EXE_OPTIONS pnut.c -o $TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe"
 
   chmod +x $TEMP_DIR/pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-exe-compiled-by-pnut-sh-sh.exe
 

--- a/exe.c
+++ b/exe.c
@@ -57,8 +57,10 @@ void emit_i64_le_large_imm(int imm_obj) {
 }
 #endif
 
+char write_buf[1];
 void write_i8(int n) {
-  putchar(n & 0xff);
+  write_buf[0] = (n & 0xff);
+  write(output_fd, write_buf, 1);
 }
 
 void write_2_i8(int a, int b) {

--- a/exe.c
+++ b/exe.c
@@ -146,13 +146,6 @@ void call(int lbl);
 void call_reg(int reg);
 void ret();
 
-void dup(int reg) {
-  pop_reg(reg);
-  push_reg(reg);
-  push_reg(reg);
-  grow_fs(1);
-}
-
 void load_mem_location(int dst, int base, int offset, int width, bool is_signed) {
   if (is_signed) {
     switch (width) {
@@ -2257,9 +2250,9 @@ void codegen_statement(ast node) {
       jump(lbl1);
       def_label(heap[binding + 4]);           // false jump location of previous case
       heap[binding + 4] = alloc_label(0);     // create false jump location for current case
-      dup(reg_X);                             // duplicate switch operand for the comparison
       codegen_rvalue(get_child_(CASE_KW, node, 0)); // evaluate case expression and compare it
-      pop_reg(reg_Y); pop_reg(reg_X); grow_fs(-2);
+      pop_reg(reg_Y); grow_fs(-1);
+      mov_reg_mem(reg_X, reg_SP, 0);          // get switch operand without popping it
       jump_cond_reg_reg(EQ, lbl1, reg_X, reg_Y);
       jump(heap[binding + 4]);                // condition is false => jump to next case
       def_label(lbl1);                        // start of case conditional block

--- a/pnut.c
+++ b/pnut.c
@@ -3981,7 +3981,6 @@ void handle_macro_D(char *opt) {
 int main(int argc, char **argv) {
   int i;
   ast decl;
-  char *opt;
 
 #ifdef HANDLE_SIGNALS
   signal(SIGINT, signal_callback_handler);

--- a/pnut.c
+++ b/pnut.c
@@ -4020,7 +4020,6 @@ int main(int argc, char **argv) {
           } else {
             init_ident(IDENTIFIER, argv[i] + 2); // skip '-U'
           }
-          init_ident(IDENTIFIER, argv[i] + 2);
           break;
 #else
         case 'D':

--- a/pnut.c
+++ b/pnut.c
@@ -1925,11 +1925,11 @@ void stringify() {
 // Concatenates two non-negative integers into a single integer
 // Note that this function only supports small integers, represented as positive integers.
 int paste_integers(int left_val, int right_val) {
+  int result = left_val;
+  int right_digits = right_val;
 #ifdef SUPPORT_64_BIT_LITERALS
   if (left_val < 0 || right_val < 0) fatal_error("Only small integers can be pasted");
 #endif
-  int result = left_val;
-  int right_digits = right_val;
   while (right_digits > 0) {
     result *= 10;
     right_digits /= 10;
@@ -3937,9 +3937,12 @@ ast parse_compound_statement() {
 #ifndef sh
 void handle_macro_D(char *opt) {
   char *start = opt;
+  char *macro_buf;
+  char *buf2;
+  int acc;
   while (*opt != 0 && *opt != '=') opt += 1; // Find = sign if any
 
-  char *macro_buf = malloc(opt - start + 1);
+  macro_buf = malloc(opt - start + 1);
   memcpy(macro_buf, start, opt - start);
   macro_buf[opt - start] = '\0';
 
@@ -3950,13 +3953,13 @@ void handle_macro_D(char *opt) {
       start = opt;
       while (*opt != 0 && *opt != '"') opt += 1;
       if (*opt == 0) fatal_error("Unterminated string literal");
-      char *buf2 = malloc(opt - start + 1);
+      buf2 = malloc(opt - start + 1);
       memcpy(buf2, start, opt - start);
       buf2[opt - start] = '\0';
       init_builtin_string_macro(macro_buf, buf2);
       free(buf2);
     } else if ('0' <= *opt && *opt <= '9') { // Start of integer token
-      int acc = 0;
+      acc = 0;
       while ('0' <= *opt && *opt <= '9') {
         acc *= 10;
         acc += *opt - '0';

--- a/pnut.c
+++ b/pnut.c
@@ -5,6 +5,8 @@
 #include <strings.h>
 #include <string.h>
 #include <stdint.h> // for intptr_t
+#include <fcntl.h> // for open
+#include <unistd.h> // for write
 
 #ifdef PNUT_CC
 // When bootstrapping pnut, intptr_t is not defined.
@@ -14,6 +16,18 @@
 typedef long long int intptr_t;
 #else
 typedef int intptr_t;
+#endif
+
+#ifdef PNUT_SH
+// on pnut-sh, the file can only be opened in 3 modes: read, write and append
+// if it doesn't exist, it will be created.
+#define O_WRONLY 01
+#define O_CREAT  00
+#define O_TRUNC  00
+#else
+#define O_WRONLY 01
+#define O_CREAT  0100
+#define O_TRUNC  01000
 #endif
 #endif
 
@@ -148,6 +162,7 @@ struct IncludeStack *include_stack, *include_stack2;
 FILE *fp = 0; // Current file pointer that's being read
 char* fp_filepath = 0; // The path of the current file being read
 char* include_search_path = 0; // Search path for include files
+int output_fd = 1; // Output file descriptor (1 = stdout)
 
 // Tokens and AST nodes
 enum {
@@ -3978,6 +3993,16 @@ int main(int argc, char **argv) {
   for (i = 1; i < argc; i += 1) {
     if (argv[i][0] == '-') {
       switch (argv[i][1]) {
+        case 'o':
+          // Output file name
+          if (argv[i][2] == 0) { // rest of option is in argv[i + 1]
+            i += 1;
+            output_fd = open(argv[i], O_WRONLY | O_CREAT | O_TRUNC, 0644);
+          } else {
+            output_fd = open(argv[i] + 2, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+          }
+          break;
+
         case 'D':
           if (argv[i][2] == 0) { // rest of option is in argv[i + 1]
             i += 1;

--- a/pnut.c
+++ b/pnut.c
@@ -4012,7 +4012,12 @@ int main(int argc, char **argv) {
             handle_macro_D(argv[i] + 2); // skip '-D'
           }
           break;
-
+#else
+          case 'D':
+            // pnut-sh only needs -D<macro> and no other options
+            init_builtin_int_macro(argv[i] + 2, 1); // +2 to skip -D
+            break;
+#endif
         case 'U':
           if (argv[i][2] == 0) { // rest of option is in argv[i + 1]
             i += 1;
@@ -4021,12 +4026,6 @@ int main(int argc, char **argv) {
             init_ident(IDENTIFIER, argv[i] + 2); // skip '-U'
           }
           break;
-#else
-        case 'D':
-          // pnut-sh only needs -D<macro> and no other options
-          init_builtin_int_macro(argv[i] + 2, 1); // +2 to skip -D
-          break;
-#endif
 
         case 'I':
           if (include_search_path != 0) fatal_error("only one include path allowed");

--- a/pnut.c
+++ b/pnut.c
@@ -4022,6 +4022,12 @@ int main(int argc, char **argv) {
           }
           init_ident(IDENTIFIER, argv[i] + 2);
           break;
+#else
+        case 'D':
+          // pnut-sh only needs -D<macro> and no other options
+          init_builtin_int_macro(argv[i] + 2, 1); // +2 to skip -D
+          break;
+#endif
 
         case 'I':
           if (include_search_path != 0) fatal_error("only one include path allowed");
@@ -4033,12 +4039,6 @@ int main(int argc, char **argv) {
             include_search_path = argv[i] + 2; // skip '-I'
           }
           break;
-#else
-        case 'D':
-          // pnut-sh only needs -D<macro> and no other options
-          init_builtin_int_macro(argv[i] + 2, 1); // +2 to skip -D
-          break;
-#endif
 
         default:
           putstr("Option "); putstr(argv[i]); putchar('\n');

--- a/pnut.c
+++ b/pnut.c
@@ -3934,6 +3934,7 @@ ast parse_compound_statement() {
 
 //-----------------------------------------------------------------------------
 
+#ifndef sh
 void handle_macro_D(char *opt) {
   char *start = opt;
   while (*opt != 0 && *opt != '=') opt += 1; // Find = sign if any
@@ -3974,8 +3975,8 @@ void handle_macro_D(char *opt) {
   }
 
   free(macro_buf);
-
 }
+#endif
 
 int main(int argc, char **argv) {
   int i;
@@ -3993,6 +3994,7 @@ int main(int argc, char **argv) {
   for (i = 1; i < argc; i += 1) {
     if (argv[i][0] == '-') {
       switch (argv[i][1]) {
+#ifndef sh
         case 'o':
           // Output file name
           if (argv[i][2] == 0) { // rest of option is in argv[i + 1]
@@ -4032,6 +4034,12 @@ int main(int argc, char **argv) {
             include_search_path = argv[i] + 2; // skip '-I'
           }
           break;
+#else
+        case 'D':
+          // pnut-sh only needs -D<macro> and no other options
+          init_builtin_int_macro(argv[i] + 2, 1); // +2 to skip -D
+          break;
+#endif
 
         default:
           putstr("Option "); putstr(argv[i]); putchar('\n');

--- a/pnut.c
+++ b/pnut.c
@@ -1131,9 +1131,6 @@ int CLOSE_ID;
 // Macros that are defined by the preprocessor
 int FILE__ID;
 int LINE__ID;
-int DATE__ID;
-int TIME__ID;
-int TIMESTAMP__ID;
 
 // When we parse a macro, we generally want the tokens as they are, without expanding them.
 void get_tok_macro() {
@@ -1669,52 +1666,53 @@ void init_ident_table() {
   NOT_SUPPORTED_ID = init_ident(IDENTIFIER, "NOT_SUPPORTED");
 }
 
-void init_builtin_string_macro(int macro_id, char* value) {
+int init_builtin_string_macro(char *macro_str, char* value) {
+  int macro_id = init_ident(MACRO, macro_str);
   // Macro object shape: ([(tok, val)], arity). -1 arity means it's an object-like macro
   heap[macro_id + 3] = cons(cons(cons(STRING, intern_str(value)), 0), -1);
+  return macro_id;
 }
 
-void init_builtin_int_macro(int macro_id, int value) {
+int init_builtin_int_macro(char *macro_str, int value) {
+  int macro_id = init_ident(MACRO, macro_str);
   heap[macro_id + 3] = cons(cons(cons(INTEGER, -value), 0), -1);
+  return macro_id;
 }
 
-void init_builtin_empty_macro(int macro_id) {
+int init_builtin_empty_macro(char *macro_str) {
+  int macro_id = init_ident(MACRO, macro_str);
   heap[macro_id + 3] = cons(0, -1); // -1 means it's an object-like macro, 0 means no tokens
+  return macro_id;
 }
 
 void init_pnut_macros() {
-  init_ident(MACRO, "PNUT_CC");
+  init_builtin_int_macro("PNUT_CC", 1);
+
+  init_builtin_string_macro("__DATE__", "Jan  1 1970");
+  init_builtin_string_macro("__TIME__", "00:00:00");
+  init_builtin_string_macro("__TIMESTAMP__", "Jan  1 1970 00:00:00");
+  FILE__ID = init_builtin_string_macro("__FILE__", "<unknown>");
+  LINE__ID = init_builtin_int_macro("__LINE__", 0);
 
 #if defined(sh)
-  init_ident(MACRO, "PNUT_SH");
+  init_builtin_int_macro("PNUT_SH", 1);
 #elif defined(target_i386_linux)
-  init_ident(MACRO, "PNUT_EXE");
-  init_ident(MACRO, "PNUT_EXE_32");
-  init_ident(MACRO, "PNUT_I386");
-  init_ident(MACRO, "PNUT_I386_LINUX");
+  init_builtin_int_macro("PNUT_EXE", 1);
+  init_builtin_int_macro("PNUT_EXE_32", 1);
+  init_builtin_int_macro("PNUT_I386", 1);
+  init_builtin_int_macro("PNUT_I386_LINUX", 1);
 #elif defined (target_x86_64_linux)
-  init_ident(MACRO, "PNUT_EXE");
-  init_ident(MACRO, "PNUT_EXE_64");
-  init_ident(MACRO, "PNUT_X86_64");
-  init_ident(MACRO, "PNUT_X86_64_LINUX");
+  init_builtin_int_macro("PNUT_EXE", 1);
+  init_builtin_int_macro("PNUT_EXE_64", 1);
+  init_builtin_int_macro("PNUT_X86_64", 1);
+  init_builtin_int_macro("PNUT_X86_64_LINUX", 1);
 #elif defined (target_x86_64_mac)
-  init_ident(MACRO, "PNUT_EXE");
-  init_ident(MACRO, "PNUT_EXE_64");
-  init_ident(MACRO, "PNUT_X86_64");
-  init_ident(MACRO, "PNUT_X86_64_MAC");
+  init_builtin_int_macro("PNUT_EXE", 1);
+  init_builtin_int_macro("PNUT_EXE_64", 1);
+  init_builtin_int_macro("PNUT_X86_64", 1);
+  init_builtin_int_macro("PNUT_X86_64_MAC", 1);
 #endif
 
-  FILE__ID      = init_ident(MACRO, "__FILE__");
-  LINE__ID      = init_ident(MACRO, "__LINE__");
-  DATE__ID      = init_ident(MACRO, "__DATE__");
-  TIME__ID      = init_ident(MACRO, "__TIME__");
-  TIMESTAMP__ID = init_ident(MACRO, "__TIMESTAMP__");
-
-  init_builtin_string_macro(FILE__ID, "<unknown>");
-  init_builtin_int_macro   (LINE__ID, 0);
-  init_builtin_string_macro(DATE__ID, "Jan  1 1970");
-  init_builtin_string_macro(TIME__ID, "00:00:00");
-  init_builtin_string_macro(TIMESTAMP__ID, "Jan  1 1970 00:00:00");
 }
 
 // A macro argument is represented using a list of tokens.
@@ -3939,7 +3937,7 @@ void handle_macro_D(char *opt) {
       char *buf2 = malloc(opt - start + 1);
       memcpy(buf2, start, opt - start);
       buf2[opt - start] = '\0';
-      init_builtin_string_macro(init_ident(MACRO, macro_buf), buf2);
+      init_builtin_string_macro(macro_buf, buf2);
       free(buf2);
     } else if ('0' <= *opt && *opt <= '9') { // Start of integer token
       int acc = 0;
@@ -3949,15 +3947,15 @@ void handle_macro_D(char *opt) {
         opt += 1;
       }
       if (*opt != 0) fatal_error("Invalid macro definition value");
-      init_builtin_int_macro(init_ident(MACRO, macro_buf), acc);
+      init_builtin_int_macro(macro_buf, acc);
     } else if (*opt == '\0') { // No value given, empty macro
-      init_builtin_empty_macro(init_ident(MACRO, macro_buf));
+      init_builtin_empty_macro(macro_buf);
     } else {
       fatal_error("Invalid macro definition value");
     }
   } else {
     // Default to 1 when no value is given
-    init_builtin_int_macro(init_ident(MACRO, macro_buf), 1);
+    init_builtin_int_macro(macro_buf, 1);
   }
 
   free(macro_buf);

--- a/x86.c
+++ b/x86.c
@@ -636,7 +636,8 @@ void int_i8(int n) {
   emit_2_i8(0xcd, n);
 }
 
-void syscall() {
+// syscall conflicts with a function defined in unistd.h so we use syscall_ instead.
+void syscall_() {
 
   // SYSCALL ;; Fast System Call
   // See: https://web.archive.org/web/20240620153804/https://www.felixcloutier.com/x86/syscall
@@ -857,7 +858,7 @@ void os_getchar() {
   mov_reg_imm(DX, 1);    // mov  rdx, 1   # rdx = 1 = number of bytes to read
   mov_reg_reg(SI, SP);   // mov  rsi, rsp # to the stack
   mov_reg_imm(AX, SYS_READ);    // mov  rax, SYS_READ
-  syscall();             // syscall
+  syscall_();            // syscall
   xor_reg_reg(DX, DX);   // rdx = 0
   cmp_reg_reg(AX, DX);   // cmp  eax, ebx
   pop_reg(AX);           // pop  eax
@@ -872,7 +873,7 @@ void os_putchar() {
   mov_reg_imm(DI, 1);    // mov edi, 1    # 1 = STDOUT
   mov_reg_imm(DX, 1);    // mov edx, 1    # 1 = byte count
   mov_reg_reg(SI, SP);   // mov esi, esp  # buffer is on the stack
-  syscall();             // syscall
+  syscall_();            // syscall
   pop_reg(AX);           // pop rax
 }
 
@@ -881,13 +882,13 @@ void os_fopen() {
   mov_reg_imm(SI, 0);     // mov rsi, 0 | flags
   mov_reg_imm(DX, 0);     // mov rdx, 0 | mode
   mov_reg_imm(AX, SYS_OPEN);     // mov rax, SYS_OPEN
-  syscall();              // syscall
+  syscall_();             // syscall
 }
 
 void os_fclose() {
   mov_reg_reg(DI, reg_X); // mov  rdi, reg_X  # file descriptor
   mov_reg_imm(AX, SYS_CLOSE);     // mov rax, SYS_CLOSE
-  syscall();              // syscall
+  syscall_();             // syscall
 }
 
 void os_fgetc() {
@@ -898,7 +899,7 @@ void os_fgetc() {
   mov_reg_imm(DX, 1);      // mov  rdx, 1   # rdx = 1 = number of bytes to read
   mov_reg_reg(SI, SP);     // mov  rsi, rsp # to the stack
   mov_reg_imm(AX, SYS_READ);      // mov  rax, SYS_READ
-  syscall();               // syscall
+  syscall_();              // syscall
   xor_reg_reg(DX, DX);     // rdx = 0
   cmp_reg_reg(AX, DX);     // cmp  eax, rdx
   pop_reg(AX);             // pop  eax
@@ -915,13 +916,13 @@ void os_allocate_memory(int size) {
   mov_reg_imm(R8, -1);    // mov r8, -1 (file descriptor)
   mov_reg_imm(R9, 0);     // mov r9, 0 (offset)
   mov_reg_imm(AX, SYS_MMAP);     // mov rax, SYS_MMAP
-  syscall();              // syscall
+  syscall_();             // syscall
 }
 
 void os_exit() {
   mov_reg_reg(DI, reg_X); // mov edi, reg_X  # exit status
   mov_reg_imm(AX, SYS_EXIT);    // mov eax, SYS_EXIT
-  syscall();              // syscall
+  syscall_();             // syscall
 }
 
 void os_read() {
@@ -929,7 +930,7 @@ void os_read() {
   mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # buffer
   mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # count
   mov_reg_imm(AX, SYS_READ);      // mov  rax, SYS_READ
-  syscall();               // syscall
+  syscall_();              // syscall
 }
 
 void os_write() {
@@ -937,7 +938,7 @@ void os_write() {
   mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # buffer
   mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # count
   mov_reg_imm(AX, SYS_WRITE);      // mov  rax, SYS_WRITE
-  syscall();               // syscall
+  syscall_();              // syscall
 }
 
 void os_open() {
@@ -945,13 +946,13 @@ void os_open() {
   mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # flags
   mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # mode
   mov_reg_imm(AX, SYS_OPEN);      // mov  rax, SYS_OPEN
-  syscall();               // syscall
+  syscall_();              // syscall
 }
 
 void os_close() {
   mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # file descriptor
   mov_reg_imm(AX, SYS_CLOSE);      // mov  rax, SYS_CLOSE
-  syscall();               // syscall
+  syscall_();              // syscall
 }
 
 #endif


### PR DESCRIPTION
## Context

Kaem, the minimal shell that's first bootstrapped in live-bootstrap doesn't support redirections. This means pnut must be able to write to the file by itself if we want to eventually be compatible with live-bootstrap. Also, when compilation fails, the output is mixed with the error/debugging information since they are both output to stdout.

This PR implements the `-o` command line option to specify where to write the resulting binary. It is only enabled on `pnut-exe`, with stdout being used for pnut-sh and when `-o` is not specified.

This PR also extends the `-D` option allow specifying the value of macros so that the same compilation options passed to TCC can be passed to pnut.