### PR TITLE
Add lseek/unlink syscalls, simplify syscalls/builtin libc and 

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -305,20 +305,18 @@ const int GT_U; // x > y  (unsigned)
 
 void jump_cond_reg_reg(int cond, int lbl, int reg1, int reg2);
 
-void os_getchar();
-void os_putchar();
 void os_exit();
-void os_fopen();
-void os_fclose();
-void os_fgetc();
 void os_allocate_memory(int size);
-
 void os_read();
 void os_write();
 void os_open();
 void os_close();
 void os_seek();
 void os_unlink();
+
+void rt_putchar();
+void rt_debug(char* msg);
+void rt_crash(char* msg);
 
 void setup_proc_args(int global_vars_size);
 
@@ -2458,19 +2456,60 @@ void codegen_glo_decl(ast node) {
   }
 }
 
+void rt_putchar() {
+  push_reg(reg_X);            // Allocate buffer on stack containing the character
+  mov_reg_imm(reg_X, 1);      // reg_X = file descriptor (stdout)
+  mov_reg_reg(reg_Y, reg_SP); // reg_Y = buffer size
+  mov_reg_imm(reg_Z, 1);      // reg_Z = buffer address
+  os_write();
+  pop_reg(reg_X);             // Deallocate buffer
+}
+
 void rt_debug(char* msg) {
   while (*msg != 0) {
     mov_reg_imm(reg_X, *msg);
-    os_putchar();
+    rt_putchar();
     msg += 1;
   }
   mov_reg_imm(reg_X, '\n');
-  os_putchar();
+  rt_putchar();
 }
 
 void rt_crash(char* msg) {
   rt_debug(msg);
   os_exit();
+}
+
+#ifndef NO_BUILTIN_LIBC
+
+void rt_fgetc(int fd_reg) {
+  int success_lbl = alloc_label("rt_fgetc_success");
+  push_reg(reg_X);            // Allocate buffer on stack, initialized with some random value
+  mov_reg_reg(reg_X, fd_reg); // reg_X = file descriptor (stdin)
+  mov_reg_reg(reg_Y, reg_SP); // reg_Y = buffer size
+  mov_reg_imm(reg_Z, 1);      // reg_Z = buffer address
+  os_read();                  // reg_X = number of bytes read, buffer[0] = character
+
+  pop_reg(reg_Z);             // Get character from buffer and deallocate buffer
+  mov_reg_imm(reg_Y, 0);      // If read returned 0, then we're at EOF (-1)
+  jump_cond_reg_reg(NE, success_lbl, reg_X, reg_Y);
+  mov_reg_imm(reg_Z, -1);     // mov  eax, -1  # -1 on EOF
+  def_label(success_lbl);     // end label
+  mov_reg_reg(reg_X, reg_Z);  // return value
+}
+
+void rt_fopen() {
+  int fopen_success_lbl = alloc_label("fopen_success");
+
+  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
+  mov_reg_imm(reg_Y, 0); // mode
+  mov_reg_imm(reg_Z, 0); // flag
+  os_open();
+  // If open fails, it returns -1, but we need to return NULL
+  mov_reg_imm(reg_Y, 0);
+  jump_cond_reg_reg(GE, fopen_success_lbl, reg_X, reg_Y);
+  mov_reg_imm(reg_X, 0); // NULL
+  def_label(fopen_success_lbl);
 }
 
 void rt_malloc() {
@@ -2493,14 +2532,12 @@ void rt_malloc() {
 }
 
 void rt_free() {
-  // Free are NO-OP for now
-  // This function cannot be empty or it will be considered a forward reference
-  return;
-  fatal_error("rt_free: free is no-op");
+  return; // Free are NO-OP
 }
 
-void codegen_end() {
+#endif
 
+void codegen_end() {
   def_label(setup_lbl);
 
   // Allocate some space for the global variables.
@@ -2535,49 +2572,6 @@ void codegen_end() {
   def_label(exit_lbl);
   mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
   os_exit();
-
-  // getchar function
-  def_label(getchar_lbl);
-  os_getchar();
-  ret();
-
-  // putchar function
-  def_label(putchar_lbl);
-  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
-  os_putchar();
-  ret();
-
-#ifndef NO_BUILTIN_LIBC
-  // fopen function
-  def_label(fopen_lbl);
-  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
-  os_fopen();
-  ret();
-
-  // fclose function
-  def_label(fclose_lbl);
-  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
-  os_fclose();
-  ret();
-
-  // fgetc function
-  def_label(fgetc_lbl);
-  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
-  os_fgetc();
-  ret();
-
-  // malloc function
-  def_label(malloc_lbl);
-  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
-  rt_malloc();
-  ret();
-
-  // free function
-  def_label(free_lbl);
-  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
-  rt_free();
-  ret();
-#endif
 
   // read function
   def_label(read_lbl);
@@ -2614,6 +2608,10 @@ void codegen_end() {
 
   // close function
   def_label(close_lbl);
+#ifndef NO_BUILTIN_LIBC
+  // fclose is just like close because FILE * is just the file descriptor in the builtin libc
+  def_label(fclose_lbl);
+#endif
   mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
   os_close();
   ret();
@@ -2632,8 +2630,43 @@ void codegen_end() {
   os_unlink();
   ret();
 
-  // printf function stub
 #ifndef NO_BUILTIN_LIBC
+  // putchar function
+  def_label(putchar_lbl);
+  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
+  rt_putchar();
+  ret();
+
+  // getchar function
+  def_label(getchar_lbl);
+  mov_reg_imm(reg_X, 0); // stdin
+  rt_fgetc(reg_X);
+  ret();
+
+  // fopen function
+  def_label(fopen_lbl);
+  rt_fopen();
+  ret();
+
+  // fgetc function
+  def_label(fgetc_lbl);
+  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
+  rt_fgetc(reg_X);
+  ret();
+
+  // malloc function
+  def_label(malloc_lbl);
+  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
+  rt_malloc();
+  ret();
+
+  // free function
+  def_label(free_lbl);
+  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
+  rt_free();
+  ret();
+
+  // printf function stub
   def_label(printf_lbl);
   rt_crash("printf is not supported yet.");
   ret();

--- a/exe.c
+++ b/exe.c
@@ -2531,10 +2531,6 @@ void rt_malloc() {
   mov_reg_reg(reg_X, reg_Y);              // Return the old bump pointer
 }
 
-void rt_free() {
-  return; // Free are NO-OP
-}
-
 #endif
 
 void codegen_end() {
@@ -2663,7 +2659,7 @@ void codegen_end() {
   // free function
   def_label(free_lbl);
   mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
-  rt_free();
+  // Free is NO-OP
   ret();
 
   // printf function stub

--- a/exe.c
+++ b/exe.c
@@ -317,6 +317,8 @@ void os_read();
 void os_write();
 void os_open();
 void os_close();
+void os_seek();
+void os_unlink();
 
 void setup_proc_args(int global_vars_size);
 
@@ -340,6 +342,8 @@ int read_lbl;
 int write_lbl;
 int open_lbl;
 int close_lbl;
+int seek_lbl;
+int unlink_lbl;
 
 int word_size_align(int n) {
   return (n + WORD_SIZE - 1) / WORD_SIZE * WORD_SIZE;
@@ -1721,6 +1725,12 @@ void codegen_begin() {
   close_lbl = alloc_label("close");
   cgc_add_global_fun(init_ident(IDENTIFIER, "close"), close_lbl, function_type1(int_type, int_type));
 
+  seek_lbl = alloc_label("lseek");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "lseek"), seek_lbl, function_type3(int_type, int_type, int_type, int_type));
+
+  unlink_lbl = alloc_label("unlink");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "unlink"), unlink_lbl, function_type1(int_type, string_type));
+
 #ifndef NO_BUILTIN_LIBC
   printf_lbl = alloc_label("printf");
   cgc_add_global_fun(init_ident(IDENTIFIER, "printf"), printf_lbl, make_variadic_func(function_type1(int_type, string_type)));
@@ -2606,6 +2616,20 @@ void codegen_end() {
   def_label(close_lbl);
   mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
   os_close();
+  ret();
+
+  // seek function
+  def_label(seek_lbl);
+  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);   // fd
+  mov_reg_mem(reg_Y, reg_SP, 2*WORD_SIZE); // offset
+  mov_reg_mem(reg_Z, reg_SP, 3*WORD_SIZE); // whence
+  os_seek();
+  ret();
+
+  // unlink function
+  def_label(unlink_lbl);
+  mov_reg_mem(reg_X, reg_SP, WORD_SIZE);   // filename
+  os_unlink();
   ret();
 
   // printf function stub

--- a/exe.c
+++ b/exe.c
@@ -1692,6 +1692,7 @@ void codegen_begin() {
   putchar_lbl = alloc_label("putchar");
   cgc_add_global_fun(init_ident(IDENTIFIER, "putchar"), putchar_lbl, function_type1(void_type, char_type));
 
+#ifndef NO_BUILTIN_LIBC
   fopen_lbl = alloc_label("fopen");
   cgc_add_global_fun(init_ident(IDENTIFIER, "fopen"), fopen_lbl, function_type2(int_type, string_type, string_type));
 
@@ -1706,6 +1707,7 @@ void codegen_begin() {
 
   free_lbl = alloc_label("free");
   cgc_add_global_fun(init_ident(IDENTIFIER, "free"), free_lbl, function_type1(void_type, void_star_type));
+#endif
 
   read_lbl = alloc_label("read");
   cgc_add_global_fun(init_ident(IDENTIFIER, "read"), read_lbl, function_type3(int_type, int_type, void_star_type, int_type));
@@ -1719,8 +1721,10 @@ void codegen_begin() {
   close_lbl = alloc_label("close");
   cgc_add_global_fun(init_ident(IDENTIFIER, "close"), close_lbl, function_type1(int_type, int_type));
 
+#ifndef NO_BUILTIN_LIBC
   printf_lbl = alloc_label("printf");
   cgc_add_global_fun(init_ident(IDENTIFIER, "printf"), printf_lbl, make_variadic_func(function_type1(int_type, string_type)));
+#endif
 
   jump(setup_lbl);
 }
@@ -2533,6 +2537,7 @@ void codegen_end() {
   os_putchar();
   ret();
 
+#ifndef NO_BUILTIN_LIBC
   // fopen function
   def_label(fopen_lbl);
   mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
@@ -2562,6 +2567,7 @@ void codegen_end() {
   mov_reg_mem(reg_X, reg_SP, WORD_SIZE);
   rt_free();
   ret();
+#endif
 
   // read function
   def_label(read_lbl);
@@ -2603,9 +2609,11 @@ void codegen_end() {
   ret();
 
   // printf function stub
+#ifndef NO_BUILTIN_LIBC
   def_label(printf_lbl);
   rt_crash("printf is not supported yet.");
   ret();
+#endif
 
   assert_all_labels_defined();
 

--- a/exe.c
+++ b/exe.c
@@ -1688,29 +1688,6 @@ void codegen_begin() {
   exit_lbl = alloc_label("exit");
   cgc_add_global_fun(init_ident(IDENTIFIER, "exit"), exit_lbl, function_type1(void_type, int_type));
 
-  getchar_lbl = alloc_label("getchar");
-  cgc_add_global_fun(init_ident(IDENTIFIER, "getchar"), getchar_lbl, function_type(char_type, 0));
-
-  putchar_lbl = alloc_label("putchar");
-  cgc_add_global_fun(init_ident(IDENTIFIER, "putchar"), putchar_lbl, function_type1(void_type, char_type));
-
-#ifndef NO_BUILTIN_LIBC
-  fopen_lbl = alloc_label("fopen");
-  cgc_add_global_fun(init_ident(IDENTIFIER, "fopen"), fopen_lbl, function_type2(int_type, string_type, string_type));
-
-  fclose_lbl = alloc_label("fclose");
-  cgc_add_global_fun(init_ident(IDENTIFIER, "fclose"), fclose_lbl, function_type1(int_type, int_type));
-
-  fgetc_lbl = alloc_label("fgetc");
-  cgc_add_global_fun(init_ident(IDENTIFIER, "fgetc"), fgetc_lbl, function_type1(int_type, int_type));
-
-  malloc_lbl = alloc_label("malloc");
-  cgc_add_global_fun(init_ident(IDENTIFIER, "malloc"), malloc_lbl, function_type1(void_star_type, int_type));
-
-  free_lbl = alloc_label("free");
-  cgc_add_global_fun(init_ident(IDENTIFIER, "free"), free_lbl, function_type1(void_type, void_star_type));
-#endif
-
   read_lbl = alloc_label("read");
   cgc_add_global_fun(init_ident(IDENTIFIER, "read"), read_lbl, function_type3(int_type, int_type, void_star_type, int_type));
 
@@ -1730,6 +1707,27 @@ void codegen_begin() {
   cgc_add_global_fun(init_ident(IDENTIFIER, "unlink"), unlink_lbl, function_type1(int_type, string_type));
 
 #ifndef NO_BUILTIN_LIBC
+  putchar_lbl = alloc_label("putchar");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "putchar"), putchar_lbl, function_type1(void_type, char_type));
+
+  getchar_lbl = alloc_label("getchar");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "getchar"), getchar_lbl, function_type(char_type, 0));
+
+  fopen_lbl = alloc_label("fopen");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "fopen"), fopen_lbl, function_type2(int_type, string_type, string_type));
+
+  fclose_lbl = alloc_label("fclose");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "fclose"), fclose_lbl, function_type1(int_type, int_type));
+
+  fgetc_lbl = alloc_label("fgetc");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "fgetc"), fgetc_lbl, function_type1(int_type, int_type));
+
+  malloc_lbl = alloc_label("malloc");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "malloc"), malloc_lbl, function_type1(void_star_type, int_type));
+
+  free_lbl = alloc_label("free");
+  cgc_add_global_fun(init_ident(IDENTIFIER, "free"), free_lbl, function_type1(void_type, void_star_type));
+
   printf_lbl = alloc_label("printf");
   cgc_add_global_fun(init_ident(IDENTIFIER, "printf"), printf_lbl, make_variadic_func(function_type1(int_type, string_type)));
 #endif

--- a/portable_libc/include/stdio.h
+++ b/portable_libc/include/stdio.h
@@ -43,6 +43,11 @@ size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 int fputs(const char *s, FILE *stream);
 int puts(const char *s);
 
+size_t fread(void *buffer, size_t size, size_t count, FILE *stream);
+int fseek( FILE* stream, long offset, int origin );
+long ftell( FILE* stream );
+int remove(const char *_Filename);
+
 int vfprintf(FILE *stream, const char *format, va_list ap);
 int fprintf(FILE *stream, const char *format VAR_ARGS);
 int printf(const char *format VAR_ARGS);

--- a/portable_libc/include/string.h
+++ b/portable_libc/include/string.h
@@ -1,3 +1,5 @@
+#ifndef _STRING_H
+
 #include "sys/types.h"
 
 void *memset(void *dest, int c, size_t n);
@@ -11,3 +13,10 @@ char *strcat(char *dest, const char *src);
 char *strchr(const char *s, int c);
 char *strrchr(const char *s, int c);
 int strcmp(const char *l, const char *r);
+
+char *strerror(int errnum);
+int strncmp(const char *s1, const char *s2, size_t n);
+char *strpbrk(const char *dest, const char *breakset);
+char *strstr (char *__haystack, char *__needle);
+
+#endif

--- a/portable_libc/include/unistd.h
+++ b/portable_libc/include/unistd.h
@@ -14,7 +14,9 @@ int open(const char *pathname, int flags, mode_t mode);
 int close(int fd);
 
 off_t lseek(int fd, off_t offset, int whence);
+int unlink(const char *pathname);
 
 char *getcwd(char *buf, size_t size);
+int execvp(const char *__file, char **__argv);
 
 #endif

--- a/portable_libc/src/stdio.c
+++ b/portable_libc/src/stdio.c
@@ -49,6 +49,22 @@ int fclose(FILE *stream) {
   return 0; /*TODO*/
 }
 
+int fseek(FILE* stream, long offset, int origin) {
+  return lseek(_get_fd(stream), offset, origin);
+}
+
+off_t ftell(FILE * stream) {
+  return lseek (_get_fd(stream), 0, SEEK_CUR);
+}
+
+size_t fread(void *data, size_t size, size_t count, FILE *stream) {
+  return read(_get_fd(stream), data, size * count) / size;
+}
+
+int remove(const char *filename) {
+  return unlink(filename);
+}
+
 char _output_buf[1];
 
 int fputc(int c, FILE *stream) {

--- a/portable_libc/src/unistd.c
+++ b/portable_libc/src/unistd.c
@@ -8,15 +8,12 @@ ssize_t read(int fd, void *buf, size_t count);
 ssize_t write(int fd, void *buf, size_t count);
 int open(const char *pathname, int flags, mode_t mode);
 int close(int fd);
+off_t lseek(int fd, off_t offset, int whence);
+int unlink(const char *pathname);
 
 */
 
 #ifdef PNUT_CC
-
-off_t lseek(int fd, off_t offset, int whence) {
-  /*TODO*/
-  return 0;
-}
 
 char *getcwd(char *buf, size_t size) {
   /*

--- a/x86.c
+++ b/x86.c
@@ -695,73 +695,6 @@ void mov_reg_lbl(int reg, int lbl) {
 // For 32 bit linux.
 #ifdef target_i386_linux
 
-void os_getchar() {
-  int lbl = alloc_label("get_char_eof");
-  push_reg(BX);           // save address of global variables table
-  mov_reg_imm(AX, 0);     // mov  eax, 0
-  push_reg(AX);           // push eax      # buffer to read byte
-  mov_reg_imm(BX, 0);     // mov  ebx, 0   # ebx = 0 = STDIN
-  mov_reg_imm(DX, 1);     // mov  edx, 1   # edx = 1 = number of bytes to read
-  mov_reg_reg(CX, SP);    // mov  ecx, esp # to the stack
-  mov_reg_imm(AX, 3);     // mov  eax, 3   # SYS_READ
-  int_i8(0x80);           // int  0x80     # system call
-  xor_reg_reg(DX, DX);    // edx = 0
-  cmp_reg_reg(AX, DX);    // cmp  eax, edx
-  pop_reg(AX);            // pop  eax
-  jump_cond(NE, lbl);     // jne  lbl      # if byte was read don't return EOF
-  mov_reg_imm(AX, -1);    // mov  eax, -1  # -1 on EOF
-  def_label(lbl);         // end label
-  pop_reg(BX);            // restore address of global variables table
-}
-
-void os_putchar() {
-  push_reg(BX);           // save address of global variables table
-  push_reg(AX);           // push eax      # buffer to write byte
-  mov_reg_imm(BX, 1);     // mov  ebx, 1   # ebx = 1 = STDOUT
-  mov_reg_imm(DX, 1);     // mov  edx, 1   # edx = 1 = number of bytes to write
-  mov_reg_reg(CX, SP);    // mov  ecx, esp # from the stack
-  mov_reg_imm(AX, 4);     // mov  eax, 4   # SYS_WRITE
-  int_i8(0x80);           // int  0x80     # system call
-  pop_reg(AX);            // pop  eax
-  pop_reg(BX);            // restore address of global variables table
-}
-
-void os_fopen() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, AX);    // mov ebx, eax | file name
-  mov_reg_imm(AX, 5);     // mov eax, 5 == SYS_OPEN
-  mov_reg_imm(CX, 0);     // mov ecx, 0 | flags
-  mov_reg_imm(DX, 0);     // mov edx, 0 | mode
-  int_i8(0x80);           // int  0x80     # system call
-  pop_reg(BX);            // restore address of global variables table
-}
-
-void os_fclose() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov  ebx, file descriptor
-  mov_reg_imm(AX, 6);     // mov  eax, 6 == SYS_CLOSE
-  int_i8(0x80);           // int  0x80     # system call
-  pop_reg(BX);            // restore address of global variables table
-}
-
-void os_fgetc() {
-  int lbl = alloc_label("fgetc_eof"); // label for EOF
-  push_reg(BX);             // save address of global variables table
-  mov_reg_reg(BX, reg_X);   // mov  ebx, file descriptor
-  mov_reg_imm(AX, 3);       // mov  eax, 3 == SYS_READ
-  push_reg(AX);             // push eax      # buffer to read byte
-  mov_reg_imm(DX, 1);       // mov  edx, 1   # edx = 1 = number of bytes to read
-  mov_reg_reg(CX, SP);      // mov  ecx, esp # to the stack
-  int_i8(0x80);             // int  0x80     # system call
-  xor_reg_reg(BX, BX);      // xor  ebx, ebx
-  cmp_reg_reg(AX, BX);      // cmp  eax, ebx
-  pop_reg(AX);              // pop  eax
-  jump_cond(NE, lbl);       // jne  lbl      # if byte was read don't return EOF
-  mov_reg_imm(AX, -1);      // mov  eax, -1  # -1 on EOF
-  def_label(lbl);           // end label
-  pop_reg(BX);              // restore address of global variables table
-}
-
 void os_allocate_memory(int size) {
   push_reg(BX);           // save address of global variables table
   mov_reg_imm(AX, 192);   // mov  eax, 192 == SYS_MMAP2
@@ -868,64 +801,6 @@ void os_unlink() {
 // For 64 bit System V ABI.
 #ifdef SYSTEM_V_ABI
 
-void os_getchar() {
-  int lbl = alloc_label("get_char_eof");
-  mov_reg_imm(AX, 0);    // mov  eax, 0
-  push_reg(AX);          // push eax      # buffer to read byte
-  mov_reg_imm(DI, 0);    // mov  edi, 0   # edi = 0 = STDIN
-  mov_reg_imm(DX, 1);    // mov  rdx, 1   # rdx = 1 = number of bytes to read
-  mov_reg_reg(SI, SP);   // mov  rsi, rsp # to the stack
-  mov_reg_imm(AX, SYS_READ);    // mov  rax, SYS_READ
-  syscall_();            // syscall
-  xor_reg_reg(DX, DX);   // rdx = 0
-  cmp_reg_reg(AX, DX);   // cmp  eax, ebx
-  pop_reg(AX);           // pop  eax
-  jump_cond(NE, lbl);    // jne  lbl      # if byte was read don't return EOF
-  mov_reg_imm(AX, -1);   // mov  eax, -1  # -1 on EOF
-  def_label(lbl);        // end label
-}
-
-void os_putchar() {
-  push_reg(AX);          // push rax      # buffer to write byte
-  mov_reg_imm(AX, SYS_WRITE);    // mov rax, SYS_WRITE
-  mov_reg_imm(DI, 1);    // mov edi, 1    # 1 = STDOUT
-  mov_reg_imm(DX, 1);    // mov edx, 1    # 1 = byte count
-  mov_reg_reg(SI, SP);   // mov esi, esp  # buffer is on the stack
-  syscall_();            // syscall
-  pop_reg(AX);           // pop rax
-}
-
-void os_fopen() {
-  mov_reg_reg(DI, AX);    // mov rdi, rax | file name
-  mov_reg_imm(SI, 0);     // mov rsi, 0 | flags
-  mov_reg_imm(DX, 0);     // mov rdx, 0 | mode
-  mov_reg_imm(AX, SYS_OPEN);     // mov rax, SYS_OPEN
-  syscall_();             // syscall
-}
-
-void os_fclose() {
-  mov_reg_reg(DI, reg_X); // mov  rdi, reg_X  # file descriptor
-  mov_reg_imm(AX, SYS_CLOSE);     // mov rax, SYS_CLOSE
-  syscall_();             // syscall
-}
-
-void os_fgetc() {
-  int lbl = alloc_label("fgetc_eof"); // label for EOF
-  mov_reg_reg(DI, reg_X);  // mov  edi, file descriptor
-  mov_reg_imm(AX, 0);      // mov  eax, 0
-  push_reg(AX);            // push eax      # buffer to read byte
-  mov_reg_imm(DX, 1);      // mov  rdx, 1   # rdx = 1 = number of bytes to read
-  mov_reg_reg(SI, SP);     // mov  rsi, rsp # to the stack
-  mov_reg_imm(AX, SYS_READ);      // mov  rax, SYS_READ
-  syscall_();              // syscall
-  xor_reg_reg(DX, DX);     // rdx = 0
-  cmp_reg_reg(AX, DX);     // cmp  eax, rdx
-  pop_reg(AX);             // pop  eax
-  jump_cond(NE, lbl);      // jne  lbl      # if byte was read don't return EOF
-  mov_reg_imm(AX, -1);     // mov  eax, -1  # -1 on EOF
-  def_label(lbl);          // end label
-}
-
 void os_allocate_memory(int size) {
   mov_reg_imm(DI, 0);     // mov rdi, 0 | NULL
   mov_reg_imm(SI, size);  // mov rsi, size | size
@@ -978,13 +853,13 @@ void os_seek() {
   mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # offset
   mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # whence
   mov_reg_imm(AX, 8);      // mov  rax, 8      # SYS_LSEEK
-  syscall();               // syscall
+  syscall_();              // syscall
 }
 
 void os_unlink() {
   mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # filename
   mov_reg_imm(AX, 87);     // mov  rax, 87     # SYS_UNLINK
-  syscall();               // syscall
+  syscall_();              // syscall
 }
 
 #endif

--- a/x86.c
+++ b/x86.c
@@ -821,6 +821,24 @@ void os_close() {
   pop_reg(BX);            // restore address of global variables table
 }
 
+void os_seek() {
+  push_reg(BX);           // save address of global variables table
+  mov_reg_reg(BX, reg_X); // mov ebx, reg_X  # file descriptor
+  mov_reg_reg(CX, reg_Y); // mov ecx, reg_Y  # offset
+  mov_reg_reg(DX, reg_Z); // mov edx, reg_Z  # whence
+  mov_reg_imm(AX, 19);    // mov eax, 19     # 19 = SYS_LSEEK
+  int_i8(0x80);           // int  0x80       # system call
+  pop_reg(BX);            // restore address of global variables table
+}
+
+void os_unlink() {
+  push_reg(BX);           // save address of global variables table
+  mov_reg_reg(BX, reg_X); // mov ebx, reg_X  # filename
+  mov_reg_imm(AX, 10);    // mov eax, 10     # 10 = SYS_UNLINK
+  int_i8(0x80);           // int  0x80       # system call
+  pop_reg(BX);            // restore address of global variables table
+}
+
 #endif
 
 // Both x86_64_linux and x86_64_mac use the System V ABI, the difference is in the system calls.
@@ -953,6 +971,20 @@ void os_close() {
   mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # file descriptor
   mov_reg_imm(AX, SYS_CLOSE);      // mov  rax, SYS_CLOSE
   syscall_();              // syscall
+}
+
+void os_seek() {
+  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # file descriptor
+  mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # offset
+  mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # whence
+  mov_reg_imm(AX, 8);      // mov  rax, 8      # SYS_LSEEK
+  syscall();               // syscall
+}
+
+void os_unlink() {
+  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # filename
+  mov_reg_imm(AX, 87);     // mov  rax, 87     # SYS_UNLINK
+  syscall();               // syscall
 }
 
 #endif

--- a/x86.c
+++ b/x86.c
@@ -636,15 +636,6 @@ void int_i8(int n) {
   emit_2_i8(0xcd, n);
 }
 
-// syscall conflicts with a function defined in unistd.h so we use syscall_ instead.
-void syscall_() {
-
-  // SYSCALL ;; Fast System Call
-  // See: https://web.archive.org/web/20240620153804/https://www.felixcloutier.com/x86/syscall
-
-  emit_2_i8(0x0F, 0x05);
-}
-
 void setup_proc_args(int global_vars_size) {
   // See page 54 of Intel386 System V ABI document:
   // https://web.archive.org/web/20240107061436/https://www.sco.com/developers/devspecs/abi386-4.pdf
@@ -695,6 +686,24 @@ void mov_reg_lbl(int reg, int lbl) {
 // For 32 bit linux.
 #ifdef target_i386_linux
 
+// Regular system calls for 32 bit linux.
+// The system call number is passed in the rax register.
+// Other arguments are passed in ebx, ecx and edx.
+// The return value is in rax.
+// If the parameter registers are ebx, ecx or edx, the function assume they may
+// be clobberred in the order of the mov instructions.
+// i.e. syscall_3(SYS_READ, ..., ebx, ...) is not valid because ebx is clobberred by the first mov instructions.
+// For syscalls that use less than 3 parameters, the extra register params are set to -1.
+void syscall_3(int syscall_code, int bx_reg, int cx_reg, int dx_reg) {
+  push_reg(BX);                  // save address of global variables table
+  if (bx_reg >= 0) mov_reg_reg(BX, bx_reg);
+  if (cx_reg >= 0) mov_reg_reg(CX, cx_reg);
+  if (dx_reg >= 0) mov_reg_reg(DX, dx_reg);
+  mov_reg_imm(AX, syscall_code); // AX = syscall_code
+  int_i8(0x80);                  // syscall
+  pop_reg(BX);                   // restore address of global variables table
+}
+
 void os_allocate_memory(int size) {
   push_reg(BX);           // save address of global variables table
   mov_reg_imm(AX, 192);   // mov  eax, 192 == SYS_MMAP2
@@ -709,67 +718,31 @@ void os_allocate_memory(int size) {
 }
 
 void os_exit() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov  ebx, reg_X  # exit status
-  mov_reg_imm(AX, 1);     // mov  eax, 1      # 1 = SYS_EXIT
-  int_i8(0x80);           // int  0x80        # system call
-  pop_reg(BX);            // restore address of global variables table
+  syscall_3(1, reg_X, -1, -1); // SYS_EXIT = 1
 }
 
 void os_read() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov ebx, reg_X  # file descriptor
-  mov_reg_reg(CX, reg_Y); // mov ecx, reg_Y  # buffer
-  mov_reg_reg(DX, reg_Z); // mov edx, reg_Z  # count
-  mov_reg_imm(AX, 3);     // mov eax, 3      # 3 = SYS_READ
-  int_i8(0x80);           // int  0x80       # system call
-  pop_reg(BX);            // restore address of global variables table
+  syscall_3(3, reg_X, reg_Y, reg_Z); // SYS_READ = 3
 }
 
 void os_write() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov ebx, reg_X  # file descriptor
-  mov_reg_reg(CX, reg_Y); // mov ecx, reg_Y  # buffer
-  mov_reg_reg(DX, reg_Z); // mov edx, reg_Z  # count
-  mov_reg_imm(AX, 4);     // mov eax, 4      # 4 = SYS_READ
-  int_i8(0x80);           // int  0x80       # system call
-  pop_reg(BX);            // restore address of global variables table
+  syscall_3(4, reg_X, reg_Y, reg_Z); // SYS_WRITE = 4
 }
 
 void os_open() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov ebx, reg_X  # filename
-  mov_reg_reg(CX, reg_Y); // mov ecx, reg_Y  # flags
-  mov_reg_reg(DX, reg_Z); // mov edx, reg_Z  # mode
-  mov_reg_imm(AX, 5);     // mov eax, 5      # 5 = SYS_OPEN
-  int_i8(0x80);           // int  0x80       # system call
-  pop_reg(BX);            // restore address of global variables table
+  syscall_3(5, reg_X, reg_Y, reg_Z); // SYS_OPEN = 5
 }
 
 void os_close() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov  ebx, reg_X  # file descriptor
-  mov_reg_imm(AX, 6);     // mov  eax, 6      # 6 = SYS_CLOSE
-  int_i8(0x80);           // int  0x80        # system call
-  pop_reg(BX);            // restore address of global variables table
+  syscall_3(6, reg_X, -1, -1); // SYS_CLOSE = 6
 }
 
 void os_seek() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov ebx, reg_X  # file descriptor
-  mov_reg_reg(CX, reg_Y); // mov ecx, reg_Y  # offset
-  mov_reg_reg(DX, reg_Z); // mov edx, reg_Z  # whence
-  mov_reg_imm(AX, 19);    // mov eax, 19     # 19 = SYS_LSEEK
-  int_i8(0x80);           // int  0x80       # system call
-  pop_reg(BX);            // restore address of global variables table
+  syscall_3(19, reg_X, reg_Y, reg_Z); // SYS_LSEEK = 19
 }
 
 void os_unlink() {
-  push_reg(BX);           // save address of global variables table
-  mov_reg_reg(BX, reg_X); // mov ebx, reg_X  # filename
-  mov_reg_imm(AX, 10);    // mov eax, 10     # 10 = SYS_UNLINK
-  int_i8(0x80);           // int  0x80       # system call
-  pop_reg(BX);            // restore address of global variables table
+  syscall_3(10, reg_X, -1, -1); // SYS_UNLINK = 10
 }
 
 #endif
@@ -781,85 +754,96 @@ void os_unlink() {
   #define SYS_WRITE 1
   #define SYS_OPEN 2
   #define SYS_CLOSE 3
+  #define SYS_LSEEK 8
+  #define SYS_UNLINK 87
   #define SYS_MMAP_MAP_TYPE 0x22
   #define SYS_MMAP 9
   #define SYS_EXIT 60
 #endif
 
 #ifdef target_x86_64_mac
+  // Refer to following page for macOS system call numbers:
+  // https://web.archive.org/web/20211102014723/http://www.opensource.apple.com/source/xnu/xnu-1504.3.12/bsd/kern/syscalls.master
+  // Because it's a 64 bit system, 0x2000000 is added to the system call number.
   #define SYSTEM_V_ABI
   #define SYS_READ 0x2000003
   #define SYS_WRITE 0x2000004
   #define SYS_OPEN 0x2000005
   #define SYS_CLOSE 0x2000006
+  #define SYS_LSEEK 0x20000c7
+  #define SYS_UNLINK 0x200000a
   #define SYS_MMAP_MAP_TYPE 0x1020
   #define SYS_MMAP 0x20000C5
   #define SYS_EXIT 0x2000001
 #endif
 
-
 // For 64 bit System V ABI.
 #ifdef SYSTEM_V_ABI
 
+void syscall_() {
+
+  // SYSCALL ;; Fast System Call
+  // See: https://web.archive.org/web/20240620153804/https://www.felixcloutier.com/x86/syscall
+
+  emit_2_i8(0x0F, 0x05);
+}
+
+// Regular system calls for 64 bit linux and macOS.
+// The system call number is passed in the rax register.
+// Other arguments are passed in rdi, rsi and rdx.
+// The return value is in rax.
+// The di_reg, si_reg, dx_reg parameters
+// If the parameter registers are rdi, rsi or rdx, the function assume they may
+// be clobberred in the order of the mov instructions.
+// i.e. syscall_3(SYS_READ, ..., rdi, ...) is not valid because rdi is clobberred by the first mov instructions.
+// For syscalls that use less than 3 parameters, the extra register params are set to -1.
+void syscall_3(int syscall_code, int di_reg, int si_reg, int dx_reg) {
+  if (di_reg >= 0) mov_reg_reg(DI, di_reg);
+  if (si_reg >= 0) mov_reg_reg(SI, si_reg);
+  if (dx_reg >= 0) mov_reg_reg(DX, dx_reg);
+  mov_reg_imm(AX, syscall_code); // AX = syscall_code
+  syscall_();                    // syscall
+}
+
 void os_allocate_memory(int size) {
-  mov_reg_imm(DI, 0);     // mov rdi, 0 | NULL
-  mov_reg_imm(SI, size);  // mov rsi, size | size
-  mov_reg_imm(DX, 0x3);   // mov rdx, 0x3 | PROT_READ (0x1) | PROT_WRITE (0x2)
+  mov_reg_imm(DI, 0);                  // mov rdi, 0 | NULL
+  mov_reg_imm(SI, size);               // mov rsi, size | size
+  mov_reg_imm(DX, 0x3);                // mov rdx, 0x3 | PROT_READ (0x1) | PROT_WRITE (0x2)
   mov_reg_imm(R10, SYS_MMAP_MAP_TYPE); // mov r10, 0x21 | MAP_ANONYMOUS (0x20) | MAP_PRIVATE (0x2)
-  mov_reg_imm(R8, -1);    // mov r8, -1 (file descriptor)
-  mov_reg_imm(R9, 0);     // mov r9, 0 (offset)
-  mov_reg_imm(AX, SYS_MMAP);     // mov rax, SYS_MMAP
-  syscall_();             // syscall
+  mov_reg_imm(R8, -1);                 // mov r8, -1 (file descriptor)
+  mov_reg_imm(R9, 0);                  // mov r9, 0 (offset)
+  mov_reg_imm(AX, SYS_MMAP);           // mov rax, SYS_MMAP
+  syscall_();                          // syscall
 }
 
 void os_exit() {
-  mov_reg_reg(DI, reg_X); // mov edi, reg_X  # exit status
-  mov_reg_imm(AX, SYS_EXIT);    // mov eax, SYS_EXIT
-  syscall_();             // syscall
+  syscall_3(SYS_EXIT, reg_X, -1, -1);
 }
 
 void os_read() {
-  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # file descriptor
-  mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # buffer
-  mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # count
-  mov_reg_imm(AX, SYS_READ);      // mov  rax, SYS_READ
-  syscall_();              // syscall
+  syscall_3(SYS_READ, reg_X, reg_Y, reg_Z);
 }
 
 void os_write() {
-  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # file descriptor
-  mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # buffer
-  mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # count
-  mov_reg_imm(AX, SYS_WRITE);      // mov  rax, SYS_WRITE
-  syscall_();              // syscall
+  syscall_3(SYS_WRITE, reg_X, reg_Y, reg_Z);
 }
 
 void os_open() {
-  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # filename
-  mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # flags
-  mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # mode
-  mov_reg_imm(AX, SYS_OPEN);      // mov  rax, SYS_OPEN
-  syscall_();              // syscall
+  syscall_3(SYS_OPEN, reg_X, reg_Y, reg_Z);
+  // MacOS (BSD) signals errors by setting the carry flag, while Linux uses a negative return value.
+  // For now, we'll assume macOS and Linux have the same behavior and return a negative value in rax.
 }
 
 void os_close() {
-  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # file descriptor
-  mov_reg_imm(AX, SYS_CLOSE);      // mov  rax, SYS_CLOSE
-  syscall_();              // syscall
+  syscall_3(SYS_CLOSE, reg_X, -1, -1);
 }
 
 void os_seek() {
-  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # file descriptor
-  mov_reg_reg(SI, reg_Y);  // mov  rsi, reg_Y  # offset
-  mov_reg_reg(DX, reg_Z);  // mov  rdx, reg_Z  # whence
-  mov_reg_imm(AX, 8);      // mov  rax, 8      # SYS_LSEEK
-  syscall_();              // syscall
+  syscall_3(SYS_LSEEK, reg_X, reg_Y, reg_Z);
 }
 
 void os_unlink() {
-  mov_reg_reg(DI, reg_X);  // mov  rdi, reg_X  # filename
-  mov_reg_imm(AX, 87);     // mov  rax, 87     # SYS_UNLINK
-  syscall_();              // syscall
+  syscall_3(SYS_UNLINK, reg_X, -1, -1);
 }
 
 #endif


### PR DESCRIPTION
## Context

For TCC, we need the lseek and unlink syscalls to implement `fseek`, `fteel` and `remove`. This PR also refactors the built-in runtime library so it lives in exe.c instead of being specific to each code generator, and adds an option to not include the built-in libc in the generated code.