### PR TITLE
Remove backtracking from pnut parser

### DIFF
--- a/examples/repl.c
+++ b/examples/repl.c
@@ -1,4 +1,4 @@
-// pnut-options: -DSH_SAVE_VARS_WITH_SET -URT_COMPACT
+// pnut-options: -DSH_SAVE_VARS_WITH_SET -DALLOW_RECURSIVE_MACROS -URT_COMPACT
 /*
  * A R4RS repl compiled with the Ribbit Scheme Compiler. This C file includes
  * a bytecode interpreter for the Ribbit Virtual Machine (RVM) and a garbage collector.

--- a/pnut.c
+++ b/pnut.c
@@ -3250,7 +3250,7 @@ ast parse_parenthesized_expression(bool first_par_already_consumed) {
   ast result;
 
   if (!first_par_already_consumed) {
-  expect_tok('(');
+    expect_tok('(');
   }
 
   result = parse_comma_expression();
@@ -3316,7 +3316,7 @@ ast parse_postfix_expression(ast result) {
   ast child;
 
   if (result == 0) {
-  result = parse_primary_expression();
+    result = parse_primary_expression();
   }
 
   while (1) {
@@ -3421,13 +3421,10 @@ ast parse_unary_expression() {
       get_tok();
       // May be a type or an expression
       if (is_type_starter(tok)) {
-      result = parse_declarator(true, parse_declaration_specifiers(false));
-      expect_tok(')');
+        result = parse_declarator(true, parse_declaration_specifiers(false));
+        expect_tok(')');
       } else {
-        // We need to put the current token and '(' back on the token stream.
-        // Otherwise, sizeof (cast_expression) fails to parse.
-        undo_token('(', 0);
-        result = parse_unary_expression();
+        result = parse_unary_expression_with_parens_prefix();
       }
     } else {
       result = parse_unary_expression();
@@ -3484,12 +3481,11 @@ ast parse_cast_expression() {
       result = new_ast2(CAST, type, parse_cast_expression());
       return result;
     } else {
-      // We need to put the current token and '(' back on the token stream.
-      undo_token('(', 0);
+      return parse_unary_expression_with_parens_prefix();
     }
+  } else {
+    return parse_unary_expression();
   }
-
-  return parse_unary_expression();
 }
 
 ast parse_multiplicative_expression() {

--- a/pnut.c
+++ b/pnut.c
@@ -1838,6 +1838,12 @@ void begin_macro_expansion(int ident, int tokens, int args) {
   macro_args    = args;
 }
 
+// The macro_is_already_expanding function is buggy and has false positives in
+// the repl example. Disable it until we rework macro argument expansion as
+// described in https://web.archive.org/web/20250328104901/https://gcc.gnu.org/onlinedocs/cpp/Macro-Arguments.html.
+#ifdef ALLOW_RECURSIVE_MACROS
+#define macro_is_already_expanding(ident) false
+#else
 // Search the macro stack to see if the macro is already expanding.
 bool macro_is_already_expanding(int ident) {
   int i = macro_stack_ix;
@@ -1851,6 +1857,7 @@ bool macro_is_already_expanding(int ident) {
   }
   return false;
 }
+#endif
 
 // Undoes the effect of get_tok by replacing the current token with the previous
 // token and saving the current token to be returned by the next call to get_tok.


### PR DESCRIPTION
## Context

When [cast expressions were implemented](https://github.com/udem-dlteam/pnut/pull/26), it wasn't obvious how to parse them without having to push back tokens on the token stream when backtracking without making the rest of the parser too complex. Turns out there's only 1 other case in the grammar that starts with parenthesis (corresponding to `parse_parenthesized_expression`) so we only need to make small changes to that function so it can skip the opening parenthesis when it has already been consumed by the parser.

### Results

It makes `pnut-sh.sh` slightly longer (7873 -> 7881 LOC), but overall it takes less memory as shown in the data below (heap_alloc is ~1000 lower, but string_pool_alloc is ~100 larger). It should also be faster since `undo_token` was called whenever a parenthesized expression was parsed (around ~200 times when compiling pnut-sh) since casts come first in precedence.

```
# Before
# string_pool_alloc=41962 heap_alloc=144547 max_text_alloc=14432 cumul_text_alloc=232878

# After
# string_pool_alloc=42031 heap_alloc=143490 max_text_alloc=14432 cumul_text_alloc=233126
```