### PR TITLE
Remove use of struct from pnut's source code

### DIFF
--- a/sh.c
+++ b/sh.c
@@ -3,7 +3,6 @@
 #include "sh-runtime.c"
 
 void handle_shell_include() {
-  FILE* shell_include_fp;
   int c;
   if (tok == STRING) {
     // Include pack_string and unpack_string functions
@@ -11,12 +10,12 @@ void handle_shell_include() {
     runtime_use_put_pstr = true;
     runtime_use_unpack_string = true;
     // Include the file as-is without any preprocessing
-    shell_include_fp = fopen_source_file(STRING_BUF(val), include_stack->dirname);
-    while ((c = fgetc(shell_include_fp)) != EOF) {
+    include_file(STRING_BUF(val), fp_dirname);
+    while ((c = fgetc(fp)) != EOF) {
       putchar(c);
     }
     putchar('\n');
-    fclose(shell_include_fp);
+    restore_include_context();
     get_tok_macro(); // Skip the string
   } else {
     putstr("tok="); putint(tok); putchar('\n');


### PR DESCRIPTION
## Context

In pnut's earlier days, the development process was very bootstrap-driven; once pnut supported a new C feature, the pnut source code started relying on that feature. When we implemented structs, we thought they would be more useful and started using them, but they were only used for the `#include` logic. For consistency and to make pnut easier to bootstrap with compilers that don't support structures (C4 for example), this PR removes the only struct declaration from pnut's code, replacing it with a stack (array + index).

This is a bit less flexible than using a struct since it sets a maximum depth on `#includes`. However, POSIX shell only requires 10 different file descriptors (See below), meaning pnut-sh.sh could already only reliably open up to 10 files. 

### POSIX 2.7 Redirection

> Open files are represented by decimal numbers starting with zero. The largest possible value is implementation-defined; however, all implementations shall support at least 0 to 9, inclusive, for use by the application.

