### PR TITLE
Simplify main function epilogue 

### DIFF
--- a/examples/compiled/all-chars.sh
+++ b/examples/compiled/all-chars.sh
@@ -32,4 +32,6 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/base64.sh
+++ b/examples/compiled/base64.sh
@@ -245,8 +245,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-__code=0; # Success exit code
-_main __code $__argc_for_main $__argv_for_main; exit $__code
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/c4.sh
+++ b/examples/compiled/c4.sh
@@ -1832,8 +1832,8 @@ make_argv() {
 # Local variables
 __=0
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-__code=0; # Success exit code
-_main __code $__argc_for_main $__argv_for_main; exit $__code
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/cat.sh
+++ b/examples/compiled/cat.sh
@@ -294,8 +294,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-__code=0; # Success exit code
-_main __code $__argc_for_main $__argv_for_main; exit $__code
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/cp.sh
+++ b/examples/compiled/cp.sh
@@ -264,8 +264,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-__code=0; # Success exit code
-_main __code $__argc_for_main $__argv_for_main; exit $__code
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/echo.sh
+++ b/examples/compiled/echo.sh
@@ -85,7 +85,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-_main __ $__argc_for_main $__argv_for_main
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/empty.sh
+++ b/examples/compiled/empty.sh
@@ -7,4 +7,6 @@ _main() {
 }
 
 # Runtime library
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/fib.sh
+++ b/examples/compiled/fib.sh
@@ -46,4 +46,6 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/hello.sh
+++ b/examples/compiled/hello.sh
@@ -7,5 +7,6 @@ _main() {
 }
 
 # Runtime library
-__code=0; # Success exit code
-_main __code; exit $__code
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/non_zero.sh
+++ b/examples/compiled/non_zero.sh
@@ -74,4 +74,6 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/print-reverse.sh
+++ b/examples/compiled/print-reverse.sh
@@ -103,7 +103,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-_main __ $__argc_for_main $__argv_for_main
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/repl.sh
+++ b/examples/compiled/repl.sh
@@ -1143,5 +1143,6 @@ _close() { # $2: fd
 # Local variables
 __=0
 
-__code=0; # Success exit code
-_main __code; exit $__code
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/reverse.sh
+++ b/examples/compiled/reverse.sh
@@ -84,7 +84,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-_main __ $__argc_for_main $__argv_for_main
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/select-file.sh
+++ b/examples/compiled/select-file.sh
@@ -299,4 +299,6 @@ unpack_string() {
   : $((_$__ptr = 0))
 }
 
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/sha256sum.sh
+++ b/examples/compiled/sha256sum.sh
@@ -510,8 +510,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-__code=0; # Success exit code
-_main __code $__argc_for_main $__argv_for_main; exit $__code
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/sum-array.sh
+++ b/examples/compiled/sum-array.sh
@@ -60,4 +60,6 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/wc-stdin.sh
+++ b/examples/compiled/wc-stdin.sh
@@ -85,4 +85,6 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/wc.sh
+++ b/examples/compiled/wc.sh
@@ -309,8 +309,8 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-# Setup argc, argv
-__argc_for_main=$(($# + 1))
-make_argv $__argc_for_main "$0" "$@"; __argv_for_main=$__argv
-__code=0; # Success exit code
-_main __code $__argc_for_main $__argv_for_main; exit $__code
+__code=0; # Exit code
+make_argv $(($# + 1)) "$0" "$@" # Setup argc/argv
+_main __code $(($# + 1)) $__argv
+
+exit $__code

--- a/examples/compiled/welcome.sh
+++ b/examples/compiled/welcome.sh
@@ -88,4 +88,6 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-_main __
+__code=0; # Exit code
+_main __code
+exit $__code

--- a/examples/compiled/winterpi.sh
+++ b/examples/compiled/winterpi.sh
@@ -69,5 +69,6 @@ endlet() { # $1: return variable
   : $(($__ret=__tmp))   # Restore return value
 }
 
-__code=0; # Success exit code
-_main __code; exit $__code
+__code=0; # Exit code
+_main __code
+exit $__code


### PR DESCRIPTION
Before this commit, there existed multiple versions of the main function epilogue, depending on whether main returned an exit code and if it used the argc/argv arguments. With this commit, the main function epilogue now only has 2 versions:
- one that uses the argc/argv arguments
- one that does not use the argc/argv arguments

The argc/argv arguments part makes sense as converting from the shell argv to the C argv pulls a lot of code from the runtime, but the exit code part doesn't save much code and makes the sh backend slightly more complex. The result is more uniform code and a pnut-sh script with a few less lines.