### PR TITLE
Use positional params for const function params

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -94,6 +94,9 @@ typedef int intptr_t;
 #if !defined(SH_SAVE_VARS_WITH_SET) && !defined(SH_INITIALIZE_PARAMS_WITH_LET)
 #define SH_SAVE_VARS_WITH_SET
 #endif
+#ifndef OPTIMIZE_CONSTANT_PARAMS_NOT
+#define OPTIMIZE_CONSTANT_PARAMS
+#endif
 // Inline ascii code of character literal
 #define SH_INLINE_CHAR_LITERAL_not
 
@@ -2612,6 +2615,20 @@ ast make_variadic_func(ast func_type) {
   set_child(func_type, 2, true); // Set the variadic flag
   return func_type;
 }
+
+#if defined(sh) && defined(OPTIMIZE_CONSTANT_PARAMS)
+// Used to optimize constant parameters of function
+bool is_constant_type(ast type) {
+  switch (get_op(type)) {
+    case '[': return false; // Array declarators cannot be marked as constant
+    case '(': return false; // Function declarators cannot be marked as constant
+    case '*': return TEST_TYPE_SPECIFIER(get_child_('*', type, 0), CONST_KW);
+    default:  return TEST_TYPE_SPECIFIER(get_child(type, 0), CONST_KW);
+  }
+}
+#else
+#define is_constant_type(type) false
+#endif
 
 // Type and declaration parser
 bool is_type_starter(int tok) {

--- a/pnut.c
+++ b/pnut.c
@@ -380,7 +380,7 @@ int heap_alloc = HASH_PRIME;
 
 int alloc_result;
 
-int alloc_obj(int size) {
+int alloc_obj(const int size) {
 
   alloc_result = heap_alloc;
 
@@ -393,11 +393,11 @@ int alloc_obj(int size) {
   return alloc_result;
 }
 
-int get_op(ast node) {
+int get_op(const ast node) {
   return heap[node] & 1023;
 }
 
-ast get_nb_children(ast node) {
+ast get_nb_children(const ast node) {
   return heap[node] >> 10;
 }
 
@@ -500,19 +500,19 @@ ast get_child_opt_go(char* file, int line, int expected_parent_node, int expecte
 
 #else
 
-int get_val(ast node) {
+int get_val(const ast node) {
   return heap[node+1];
 }
 
-void set_val(ast node, int val) {
+void set_val(const ast node, const int val) {
   heap[node+1] = val;
 }
 
-ast get_child(ast node, int i) {
+ast get_child(const ast node, const int i) {
   return heap[node+i+1];
 }
 
-void set_child(ast node, int i, ast child) {
+void set_child(const ast node, const int i, const ast child) {
   heap[node+i+1] = child;
 }
 
@@ -525,7 +525,7 @@ void set_child(ast node, int i, ast child) {
 
 ast ast_result;
 
-ast new_ast0(int op, int val) {
+ast new_ast0(const int op, const int val) {
 
   ast_result = alloc_obj(2);
 
@@ -535,7 +535,7 @@ ast new_ast0(int op, int val) {
   return ast_result;
 }
 
-ast new_ast1(int op, ast child0) {
+ast new_ast1(const int op, const ast child0) {
 
   ast_result = alloc_obj(2);
 
@@ -545,7 +545,7 @@ ast new_ast1(int op, ast child0) {
   return ast_result;
 }
 
-ast new_ast2(int op, ast child0, ast child1) {
+ast new_ast2(const int op, const ast child0, const ast child1) {
 
   ast_result = alloc_obj(3);
 
@@ -556,7 +556,7 @@ ast new_ast2(int op, ast child0, ast child1) {
   return ast_result;
 }
 
-ast new_ast3(int op, ast child0, ast child1, ast child2) {
+ast new_ast3(const int op, const ast child0, const ast child1, const ast child2) {
 
   ast_result = alloc_obj(4);
 
@@ -568,7 +568,7 @@ ast new_ast3(int op, ast child0, ast child1, ast child2) {
   return ast_result;
 }
 
-ast new_ast4(int op, ast child0, ast child1, ast child2, ast child3) {
+ast new_ast4(const int op, const ast child0, const ast child1, const ast child2, const ast child3) {
 
   ast_result = alloc_obj(5);
 
@@ -581,7 +581,7 @@ ast new_ast4(int op, ast child0, ast child1, ast child2, ast child3) {
   return ast_result;
 }
 
-ast clone_ast(ast orig) {
+ast clone_ast(const ast orig) {
   int nb_children = get_nb_children(orig);
   int i;
 
@@ -598,23 +598,21 @@ ast clone_ast(ast orig) {
   return ast_result;
 }
 
-// TODO: Use macro to avoid indirection?
-// Functions used to create and access lists.
-ast cons(int child0, int child1)    { return new_ast2(LIST, child0, child1); }
-ast car(int pair)                   { return get_child_(LIST, pair, 0); }
-ast car_(int expected_op, int pair) { return get_child__(LIST, expected_op, pair, 0); }
-ast cdr(int pair)                   { return get_child_(LIST, pair, 1); }
-ast cdr_(int expected_op, int pair) { return get_child_opt_(LIST, expected_op, pair, 1); }
-void set_car(int pair, int value)   { return set_child(pair, 0, value); }
-void set_cdr(int pair, int value)   { return set_child(pair, 1, value); }
-ast list1(int child0)               { return new_ast2(LIST, child0, 0); }
-ast list2(int child0, int child1)   { return new_ast2(LIST, child0, new_ast2(LIST, child1, 0)); }
-ast list3(int child0, int child1, int child2) { return new_ast2(LIST, child0, new_ast2(LIST, child1, new_ast2(LIST, child2, 0))); }
+ast cons(const int child0, const int child1)    { return new_ast2(LIST, child0, child1); }
+ast car(const int pair)                         { return get_child_(LIST, pair, 0); }
+ast cdr(const int pair)                         { return get_child_(LIST, pair, 1); }
+ast car_(const int expected_op, const int pair) { return get_child__(LIST, expected_op, pair, 0); }
+ast cdr_(const int expected_op, const int pair) { return get_child_opt_(LIST, expected_op, pair, 1); }
+void set_car(const int pair, const int value)   { return set_child(pair, 0, value); }
+void set_cdr(const int pair, const int value)   { return set_child(pair, 1, value); }
+ast list1(const int child0)                     { return new_ast2(LIST, child0, 0); }
+ast list2(const int child0, const int child1)   { return new_ast2(LIST, child0, new_ast2(LIST, child1, 0)); }
+ast list3(const int child0, const int child1, const int child2) { return new_ast2(LIST, child0, new_ast2(LIST, child1, new_ast2(LIST, child2, 0))); }
 #define tail(x) cdr_(LIST, x)
 
 // Returns the only element of a singleton list, if it is a singleton list.
 // Otherwise, returns 0.
-ast list_singleton(ast list) {
+ast list_singleton(const ast list) {
   if (list != 0 && tail(list) == 0) {
     return car(list);
   } else {

--- a/sh.c
+++ b/sh.c
@@ -2608,16 +2608,19 @@ void initialize_function_variables() {
   text res = 0;
   int counter = fun_gensym_ix;
 
+  // Internal variables
   while (counter > 0) {
     ident = new_fresh_ident(counter);
     res = concatenate_strings_with(res, format_special_var(ident, false), wrap_str_lit(" = "));
     counter -= 1;
   }
 
+  // Local variables and parameters
   while (env != 0) {
     ident = binding_ident(env);
-
-    res = concatenate_strings_with(res, local_var(ident), wrap_str_lit(" = "));
+    if (binding_kind(env) != BINDING_PARAM_LOCAL || !is_constant_type(heap[env + 4])) { // Skip constant params
+      res = concatenate_strings_with(res, local_var(ident), wrap_str_lit(" = "));
+    }
     env = binding_next(env);
   }
 


### PR DESCRIPTION
## Context

When a function parameter is marked with `const`, `pnut-sh` uses the positional parameter for it instead of binding it to a variable. This saves the cost of `let/endlet` for that variable, and is sometimes faster than managing local variables with `set`, as it completely remove the local variable overhead for that parameter since it uses the shell built-in mechanism.

This PR also uses this features on a few very common functions so we can evaluate the speed-up and see if it's worth tagging every constant parameter.