### PR TITLE
Use printf "%x" instead of putint if using pnut-sh

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -184,6 +184,9 @@ void putstr(char *str) {
   }
 }
 
+#ifdef PNUT_SH
+#define putint(n) printf("%d", n)
+#else
 void putint_aux(int n) {
   if (n <= -10) putint_aux(n / 10);
   putchar('0' - (n % 10));
@@ -197,6 +200,7 @@ void putint(int n) {
     putint_aux(-n);
   }
 }
+#endif
 
 void fatal_error(char *msg) {
 #ifdef INCLUDE_LINE_NUMBER_ON_ERROR

--- a/sh.c
+++ b/sh.c
@@ -205,6 +205,10 @@ text concatenate_strings_with(text t1, text t2, text sep) {
   return string_concat3(t1, sep, t2);
 }
 
+#ifdef PNUT_SH
+#define puthex_unsigned(n) printf("%x", n)
+#define putoct_unsigned(n) printf("%o", n)
+#else
 // Output unsigned integer in hex
 void puthex_unsigned(int n) {
   // Because n is signed, we clear the upper bits after shifting in case n was negative
@@ -217,6 +221,7 @@ void putoct_unsigned(int n) {
   if ((n >> 3) & 0x1fffffff) putoct_unsigned((n >> 3) & 0x1fffffff);
   putchar('0' + (n & 7));
 }
+#endif
 
 void print_escaped_char(char c, int for_printf) {
   // C escape sequences


### PR DESCRIPTION
## Context

`putint` recursively calls itself to print the value, which is inefficient considering that `printf` can do the same job in a single call, and that `printf` with constant format strings are mapped to the shell's builtin `printf`. What prevented us from doing that in the past was that `pnut-exe` didn't support `printf`. This is still the case, but now `pnut-sh` defines the `PNUT_SH` macro meaning we can detect when we're targeting the shell vs native code.
