### PR TITLE
Fix negation of constant parameters

### DIFF
--- a/examples/compiled/c4.sh
+++ b/examples/compiled/c4.sh
@@ -322,7 +322,7 @@ _next() {
 _expr() { # lev: $2
   set $@ $lev $t $d
   lev=$2
-  if [ $((!_tk)) != 0 ] ; then
+  if [ $((! _tk)) != 0 ] ; then
     printf "%d: unexpected eof in expression\n" $_line
     exit -1
   elif [ $_tk = $_Num ] ; then
@@ -483,7 +483,7 @@ _expr() { # lev: $2
     _next __
     : $((_$((_e += 1)) = _IMM))
     if [ $_tk = $_Num ] ; then
-      : $((_$((_e += 1)) = -_ival))
+      : $((_$((_e += 1)) = - _ival))
       _next __
     else
       : $((_$((_e += 1)) = -1))

--- a/examples/compiled/repl.sh
+++ b/examples/compiled/repl.sh
@@ -231,7 +231,7 @@ _init_heap() {
   if [ $((_heap_start & (1 == 1))) != 0 ] ; then
     : $(((_heap_start += 1) - 1))
   fi
-  if [ $((!_heap_start)) != 0 ] ; then
+  if [ $((! _heap_start)) != 0 ] ; then
     exit 7
   fi
   _heap_mid=$((_heap_start + (_space_size >> 1)))
@@ -530,7 +530,7 @@ _decode() {
       op=4
       _pop n
     else
-      if [ $((!op)) != 0 ] ; then
+      if [ $((! op)) != 0 ] ; then
         _push2 __ $(((0 << 1) | 1)) $(((0 << 1) | 1))
       fi
       if [ $n -ge $d ] ; then
@@ -635,7 +635,7 @@ _prim() { # no: $2
   elif [ $no = 3 ] ; then
     _pop x
     _read bytes_read $((x >> 1)) $buffer 1
-    if [ $((!bytes_read)) != 0 ] ; then
+    if [ $((! bytes_read)) != 0 ] ; then
       _push2 __ $((_$((_FALSE + __field1)))) $(((0 << 1) | 1))
     else
       _push2 __ $(((_$((buffer + 0)) << 1) | 1)) $(((0 << 1) | 1))

--- a/examples/compiled/wc-stdin.sh
+++ b/examples/compiled/wc-stdin.sh
@@ -22,7 +22,7 @@ _main() {
       : $((lines += 1))
     fi
     _is_word_separator sep $c
-    if [ $sep != 0 ] && [ $((!last_sep)) != 0 ] ; then
+    if [ $sep != 0 ] && [ $((! last_sep)) != 0 ] ; then
       : $((words += 1))
     fi
     last_sep=$sep

--- a/examples/compiled/wc.sh
+++ b/examples/compiled/wc.sh
@@ -37,7 +37,7 @@ _wc_fd() { let fd $2; let filename $3
         : $((lines += 1))
       fi
       _is_word_separator sep $((_$((_buf + i))))
-      if [ $sep != 0 ] && [ $((!last_sep)) != 0 ] ; then
+      if [ $sep != 0 ] && [ $((! last_sep)) != 0 ] ; then
         : $((words += 1))
       fi
       last_sep=$sep

--- a/sh.c
+++ b/sh.c
@@ -1300,9 +1300,18 @@ text comp_rvalue_go(ast node, int context, ast test_side_effects, int outer_op) 
       // +x is equivalent to x
       return comp_rvalue_go(child0, context, test_side_effects, outer_op);
     } else if (op == '-' || op == '~' || op == '!') {
-      if (get_op(child0) == INTEGER || op == INTEGER_HEX || op == INTEGER_OCT) {
+      if (op == '-' && (get_op(child0) == INTEGER || op == INTEGER_HEX || op == INTEGER_OCT)) {
         return wrap_in_condition_if_needed(context, test_side_effects, wrap_integer(-1, child0));
-      } else {
+      }
+#ifdef OPTIMIZE_CONSTANT_PARAMS
+      // The expansion of negative constant params prefixed with - result in
+      // --<number> which is parsed as pre-decrement. Add a space between the
+      // operator and the variable (constant param or not for consistency).
+      else if (get_op(child0) == IDENTIFIER) {
+        return wrap_if_needed(false, context, test_side_effects, string_concat3(wrap_char(op), wrap_char(' '), env_var_with_prefix(child0, false)), outer_op, op);
+      }
+#endif
+      else {
         sub1 = comp_rvalue_go(child0, RVALUE_CTX_ARITH_EXPANSION, 0, op);
         return wrap_if_needed(false, context, test_side_effects, string_concat(wrap_char(op), sub1), outer_op, op);
       }


### PR DESCRIPTION
The expansion of negative constant params prefixed with - result in --<number> which is parsed as pre-decrement. This commit fixes this issue by adding a space between the operator and the variable (constant param or not for consistency).