### PR TITLE
Add option to allocate global variables and heap on stack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           set -e
           ./run-tests.sh ${{ matrix.target }}
+          PNUT_OPTIONS="-DUSE_STACK_FOR_GLOBALS" ./run-tests.sh ${{ matrix.target }}
 
       - name: Run ${{ matrix.target }} tests on ${{ matrix.host }} with one pass generator
         run: |
@@ -102,6 +103,7 @@ jobs:
             echo "Skipping one pass generator on macOS"
           else
             ./run-tests.sh ${{ matrix.target }} --one-pass-generator
+            PNUT_OPTIONS="-DUSE_STACK_FOR_GLOBALS" ./run-tests.sh ${{ matrix.target }} --one-pass-generator
           fi
 
   tests-shell: # Run tests for pnut-sh on all supported shells

--- a/exe.c
+++ b/exe.c
@@ -2833,8 +2833,10 @@ void codegen_end() {
 #endif
 
   def_label(init_next_lbl);
-#ifdef USE_STACK_FOR_GLOBALS
+#if defined(USE_STACK_FOR_GLOBALS) && defined(ONE_PASS_GENERATOR)
   setup_proc_args(RT_GLO_SIZE + RT_HEAP_SIZE);
+#elif defined(USE_STACK_FOR_GLOBALS)
+  setup_proc_args(cgc_global_alloc + RT_HEAP_SIZE);
 #else
   setup_proc_args(0);
 #endif

--- a/exe.c
+++ b/exe.c
@@ -2827,16 +2827,16 @@ void codegen_end() {
 #ifndef ONE_PASS_GENERATOR
   def_label(setup_lbl);
   // Initialize the global variable table and heap for malloc
-  init_memory_spaces(cgc_global_alloc);
+  init_memory_spaces(word_size_align(cgc_global_alloc));
   // Jump to the initialization code
   jump(init_start_lbl);
 #endif
 
   def_label(init_next_lbl);
 #if defined(USE_STACK_FOR_GLOBALS) && defined(ONE_PASS_GENERATOR)
-  setup_proc_args(RT_GLO_SIZE + RT_HEAP_SIZE);
+  setup_proc_args(word_size_align(RT_GLO_SIZE + RT_HEAP_SIZE));
 #elif defined(USE_STACK_FOR_GLOBALS)
-  setup_proc_args(cgc_global_alloc + RT_HEAP_SIZE);
+  setup_proc_args(word_size_align(cgc_global_alloc + RT_HEAP_SIZE));
 #else
   setup_proc_args(0);
 #endif

--- a/exe.c
+++ b/exe.c
@@ -2766,7 +2766,7 @@ void init_memory_spaces(int glo_size) {
   jump_cond_reg_reg(LT, loop_lbl, reg_Z, reg_Y); //    if (reg_Z < reg_Y) goto loop;
 
   add_reg_imm(reg_Y, -glo_size); // reg_Y = start of global variables/end of heap
-  add_reg_reg(reg_glo, reg_Y);   // reg_glo = start of global variables/end of heap
+  mov_reg_reg(reg_glo, reg_Y);   // reg_glo = start of global variables/end of heap
 
   add_reg_imm(reg_Y, -RT_HEAP_SIZE); // reg_Y = start of heap
   mov_mem_reg(reg_glo, 0, reg_Y);    // Set init heap start

--- a/exe.c
+++ b/exe.c
@@ -1,7 +1,6 @@
 // common part of machine code generators
 void generate_exe();
 
-#define USE_STACK_FOR_GLOBALS
 // When placing globals on the stack, it's important that globals don't occupy
 // so much space they overflow the stack.
 #ifdef USE_STACK_FOR_GLOBALS
@@ -25,7 +24,11 @@ void generate_exe();
 #define MAX_CODE_SIZE 1000000
 #endif
 
+#ifdef ONE_PASS_GENERATOR
 #define CODE_SIZE 50000
+#else
+#define CODE_SIZE 500000
+#endif
 int code[CODE_SIZE];
 // Index of the next free byte in the code buffer
 int code_alloc = 0;

--- a/pnut.c
+++ b/pnut.c
@@ -369,7 +369,7 @@ int prev_ch = EOF;
 int tok;
 int val;
 
-#define STRING_POOL_SIZE 500000
+#define STRING_POOL_SIZE 250000
 char string_pool[STRING_POOL_SIZE];
 int string_pool_alloc = 0;
 int string_start;
@@ -378,7 +378,7 @@ int hash;
 // These parameters give a perfect hashing of the C keywords
 #define HASH_PARAM 1026
 #define HASH_PRIME 1009
-#define HEAP_SIZE 2000000
+#define HEAP_SIZE 196608 // 192 KB
 intptr_t heap[HEAP_SIZE];
 int heap_alloc = HASH_PRIME;
 

--- a/tests/_all/globals.c
+++ b/tests/_all/globals.c
@@ -22,7 +22,7 @@ void putint(int n) {
   }
 }
 
-int arr[1000000];
+int arr[10000];
 // Making sure non-word aligned globals are handled correctly. There was a bug
 // once where characters were given 1 byte of space, which caused the next
 // globals to be misaligned


### PR DESCRIPTION
## Context

https://github.com/udem-dlteam/pnut/pull/152 moved the global variables to a mmap region, but some systems don't support that system call. With pnut-exe's one-pass mode, the code buffer doesn't get too large when compiling TCC, so statically allocated buffers (and other global variables) can be placed on the stack.

See https://github.com/fosslinux/live-bootstrap/pull/524#issuecomment-2872049973 for more context.

## Concern

While the code buffer can be relatively small, other statically allocated buffers take up a lot of space. In particular, the string pool and heap buffers since they are never collected and grow proportional to the input program size. To compile TCC it may be required to increase the stack size limit even in one-pass mode.