### PR TITLE
Use direct call when function address is known

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -1311,7 +1311,7 @@ void codegen_call(ast node) {
   if (binding != 0) {
 #ifdef ONE_PASS_GENERATOR
     // When compiling in one pass mode, forward jumps must go through the jump table
-    if (is_label_defined(binding)) {
+    if (is_label_defined(fun_binding_lbl(binding))) {
       call(fun_binding_lbl(binding));
     } else {
       mov_reg_mem(reg_X, reg_glo, heap[binding+6]);


### PR DESCRIPTION
## Context

In one-pass mode, forward function calls, that is calls to functions that are not yet defined, are done indirectly by looking up the function address from a table that initialized at program initialization. Because indirect jumps are much slower, this is only done when the address of the function is not yet known, but because everything is an `int` in pnut, the `is_label_defined` function which indicated whether to use a direct or indirect call was given the wrong argument and caused all function calls to be indirect.

This bug was not caught because indirect jumps are always valid (as opposed to direct forward jumps that require a fixup and would be caught when running `pnut-exe` in one-pass and safe modes) but just slower.

This should also make the pnut-exe bootstrap on the shell slightly faster, as it decreases the maximum code buffer size by 4% from 19737 to 19033 (on x86_64_linux).