### PR TITLE
Fix pnut-lib.c for make-pnut-js script

### DIFF
--- a/pnut-lib.c
+++ b/pnut-lib.c
@@ -21,7 +21,7 @@ void compile(char* file) {
   get_tok();
 
   while (tok != EOF) {
-    decl = parse_definition(0);
+    decl = parse_declaration(false);
     codegen_glo_decl(decl);
   }
 


### PR DESCRIPTION
## Context

We haven't updated the web version of pnut hosted on pnut.sh. When I tried to today I noticed that we had broken the pnut-lib.c script when we extended the declaration parser and renamed `parse_definition` to `parse_declaration`. 