### PR TITLE
Fix positional parameter of first function when using constant parameter optimization

### DIFF
--- a/sh.c
+++ b/sh.c
@@ -2653,9 +2653,6 @@ void codegen_begin() {
 int max_text_alloc = 0;
 int cumul_text_alloc = 0;
 void codegen_glo_decl(ast decl) {
-  comp_glo_decl(decl);
-  initialize_function_variables();
-  print_glo_decls();
   // Reset text and glo decls buffers
   glo_decl_ix = 0;
   text_alloc = 1;
@@ -2663,6 +2660,10 @@ void codegen_glo_decl(ast decl) {
   // Reset local environment
   cgc_locals = cgc_locals_fun = 0;
   cgc_fs = 1; // 1 to account for the return location parameter
+
+  comp_glo_decl(decl);
+  initialize_function_variables();
+  print_glo_decls();
 
   // Statistics
   max_text_alloc = max_text_alloc > text_alloc ? max_text_alloc : text_alloc;


### PR DESCRIPTION
## Context

`cgc_fs` is a global variable counting the number of bindings in the local environment. Normally, it is initialized to 1 since the return variable is always added implicitly.

Because `cgc_fs` was set to 1 after compiling a top-level declaration to reset the counter for the next declaration, the first function of a program would be compiled with `cgc_fs` set to 0, offsetting the rest of the parameters by one.

This bug only revealed itself when using the constant parameter optimization, as the code that initialized variables with positional parameters used a different counter.