### PR TITLE
Add support for chmod/mkdir/access syscalls

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -413,6 +413,9 @@ void os_open();
 void os_close();
 void os_seek();
 void os_unlink();
+void os_mkdir();
+void os_chmod();
+void os_access();
 
 void rt_putchar();
 void rt_debug(char* msg);
@@ -2698,6 +2701,24 @@ void codegen_builtin() {
   // unlink function
   declare_builtin("unlink", false, int_type, list1(string_type));
   os_unlink();
+  ret();
+  init_forward_jump_table(cgc_globals);
+
+  // mkdir function
+  declare_builtin("mkdir", false, int_type, list2(string_type, int_type));
+  os_mkdir();
+  ret();
+  init_forward_jump_table(cgc_globals);
+
+  // chmod function
+  declare_builtin("chmod", false, int_type, list2(string_type, int_type));
+  os_chmod();
+  ret();
+  init_forward_jump_table(cgc_globals);
+
+  // stat/access function
+  declare_builtin("access", false, int_type, list2(string_type, int_type));
+  os_access();
   ret();
   init_forward_jump_table(cgc_globals);
 

--- a/x86.c
+++ b/x86.c
@@ -745,6 +745,18 @@ void os_unlink() {
   syscall_3(10, reg_X, -1, -1); // SYS_UNLINK = 10
 }
 
+void os_mkdir() {
+  syscall_3(39, reg_X, reg_Y, -1); // SYS_MKDIR = 39
+}
+
+void os_chmod() {
+  syscall_3(15, reg_X, reg_Y, -1); // SYS_CHMOD = 15
+}
+
+void os_access() {
+  syscall_3(21, reg_X, reg_Y, -1); // SYS_ACCESS = 21
+}
+
 #endif
 
 // Both x86_64_linux and x86_64_mac use the System V ABI, the difference is in the system calls.
@@ -756,6 +768,10 @@ void os_unlink() {
   #define SYS_CLOSE 3
   #define SYS_LSEEK 8
   #define SYS_UNLINK 87
+  #define SYS_MKDIR 83
+  #define SYS_CHMOD 90
+  #define SYS_ACCESS 21
+  #define SYS_STAT 4
   #define SYS_MMAP_MAP_TYPE 0x22
   #define SYS_MMAP 9
   #define SYS_EXIT 60
@@ -772,6 +788,9 @@ void os_unlink() {
   #define SYS_CLOSE 0x2000006
   #define SYS_LSEEK 0x20000c7
   #define SYS_UNLINK 0x200000a
+  #define SYS_MKDIR 0x2000088
+  #define SYS_CHMOD 0x200000f
+  #define SYS_ACCESS 0x2000021
   #define SYS_MMAP_MAP_TYPE 0x1020
   #define SYS_MMAP 0x20000C5
   #define SYS_EXIT 0x2000001
@@ -844,6 +863,18 @@ void os_seek() {
 
 void os_unlink() {
   syscall_3(SYS_UNLINK, reg_X, -1, -1);
+}
+
+void os_mkdir() {
+  syscall_3(SYS_MKDIR, reg_X, reg_Y, -1);
+}
+
+void os_chmod() {
+  syscall_3(SYS_CHMOD, reg_X, reg_Y, -1);
+}
+
+void os_access() {
+  syscall_3(SYS_ACCESS, reg_X, reg_Y, -1);
 }
 
 #endif


### PR DESCRIPTION
## Context

These system calls are used to bootstrap the build environment.

Pulling them outside of the `laurent/small-fixes-for-TCC` branch because it's causing conflicts with changes that have been merged since the last rebase.