### PR TITLE
emit_i8: fix code buffer overflow

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -109,7 +109,7 @@ void reset_code_buffer() {
 #endif
 
 void emit_i8(int a) {
-  if (code_alloc >= MAX_CODE_SIZE) {
+  if (code_alloc >= CODE_SIZE) {
     fatal_error("code buffer overflow");
   }
   code[code_alloc] = (a & 0xff);


### PR DESCRIPTION
## Context

In https://github.com/udem-dlteam/pnut/pull/194, we reduced the code buffer size from `MAX_CODE_SIZE` to `CODE_SIZE` but forgot to modify the bound check in `emit_i8`. This normally wouldn't cause issues because the code buffer was large enough to fit every program we tested with (with and without the one-pass mode), but TCC has declarations that caused the buffer to overflow. This PR fixes the bound check.