### PR TITLE
Allocate memory using brk syscall instead of mmap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,9 @@ jobs:
           set -e
           ./run-tests.sh ${{ matrix.target }}
           PNUT_OPTIONS="-D USE_STACK_FOR_GLOBALS" ./run-tests.sh ${{ matrix.target }}
-          PNUT_OPTIONS="-D USE_BRK_SYSCALL" ./run-tests.sh ${{ matrix.target }}
+          if [ ${{ matrix.host }} != "macos-latest" ]; then
+            PNUT_OPTIONS="-D USE_BRK_SYSCALL" ./run-tests.sh ${{ matrix.target }}
+          fi
 
       - name: Run ${{ matrix.target }} tests on ${{ matrix.host }} with one pass generator
         run: |
@@ -223,8 +225,8 @@ jobs:
         run: |
           set -e
           ./bootstrap-pnut-exe.sh --backend ${{ matrix.target }} --stats
-          PNUT_OPTIONS="-D USE_BRK_SYSCALL" ./bootstrap-pnut-exe.sh --backend ${{ matrix.target }} --stats
           if [ ${{ matrix.host }} != "macos-latest" ]; then
+            PNUT_OPTIONS="-D USE_BRK_SYSCALL" ./bootstrap-pnut-exe.sh --backend ${{ matrix.target }} --stats
             ./bootstrap-pnut-exe.sh --backend ${{ matrix.target }} --one-pass-generator --stats
             PNUT_OPTIONS="-D USE_BRK_SYSCALL" ./bootstrap-pnut-exe.sh --backend ${{ matrix.target }} --one-pass-generator --stats
           fi

--- a/x86.c
+++ b/x86.c
@@ -818,8 +818,10 @@ void os_access() {
   #define SYS_ACCESS 0x2000021
   #define SYS_MMAP_MAP_TYPE 0x1020
   #define SYS_MMAP 0x20000C5
-  #define SYS_BRK 0x2000011
   #define SYS_EXIT 0x2000001
+#ifdef USE_BRK_SYSCALL
+  #error "USE_BRK_SYSCALL is not supported on macOS"
+#endif
 #endif
 
 // For 64 bit System V ABI.
@@ -850,7 +852,7 @@ void syscall_3(int syscall_code, int di_reg, int si_reg, int dx_reg) {
   syscall_();                    // syscall
 }
 
-#ifdef USE_BRK_SYSCALL
+#if defined(USE_BRK_SYSCALL) && defined(SYS_BRK)
 // Use brk/sbrk syscalls instead of mmap for memory allocation
 // This is needed for environments like builder-hex0 that don't support mmap
 void os_allocate_memory(int size) {


### PR DESCRIPTION
## Context

Not every systems support the `mmap` syscall, for example [builder-hex0](https://github.com/ironmeld/builder-hex0) that bootstraps a full system from a minimal operation system. Fortunately, pnut-exe only allocates memory twice (once for globals, once for the built-in malloc implementation), so mmap can simply be substituted by brk.

This PR adds the `USE_BRK_SYSCALL` option that replaces `mmap` with `brk`. ~The `mmap` implementation is still kept as it seems to be slightly faster and may be needed in the future? If we decide to remove it, it could also be a good opportunity to simplify the x86 instruction encoder since the R9-R15 registers are only used in `os_allocate_memory`.~ MacOS has removed the `brk` syscall meaning the `mmap` implementation must be kept.

While compiling `pnut-exe` with itself and looking at the syscalls (with read and write filtered out to reduce noise), we can see that only `mmap` is no longer present.
```
brk(NULL)                               = 0x4b08d000
brk(0x5148d000)                         = 0x5148d000
brk(NULL)                               = 0x5148d000
brk(0x5788d000)                         = 0x5788d000
open("pnut.c", O_RDONLY)                = 3
open("build/pnut-x86-by-pnut-x86-by-pnut-x86-by-gcc.exe", O_WRONLY|O_CREAT|O_TRUNC, 0755) = 4
open("x86.c", O_RDONLY)                 = 5
open("exe.c", O_RDONLY)                 = 6
open("env.c", O_RDONLY)                 = 7
close(7)                                = 0
close(6)                                = 0
open("elf.c", O_RDONLY)                 = 6
close(6)                                = 0
close(5)                                = 0
exit(0)                                 = ?
+++ exited with 0 +++
```