### PR TITLE
Support indirect function calls on non-literal expressions

### DIFF
--- a/tests/_exe/indirect-calls.c
+++ b/tests/_exe/indirect-calls.c
@@ -31,6 +31,14 @@ void fun4() {
   putstr("fun4\n");
 }
 
+int return_0() {
+  return 0;
+}
+
+int (*return_0_ptr())() {
+  return &return_0;
+}
+
 void (*funs[4])() = {&fun1, &fun2, *fun3, **fun4};
 
 void calls_funs(void (*funs[])(), int n) {
@@ -61,6 +69,13 @@ int main() {
   f_ptr2(0);
   f_ptr3(0);
   f_ptr4(0);
+  funs[0]();
+  funs[3]();
+  // Indirect call on non-literal expression
+  int one = return_0_ptr()() + 1;
+  if (one != 1) {
+    return 1;
+  }
   call_fun(putstr,    "hello\n");
   call_fun(*putstr,   "hello\n");
   call_fun(&putstr,   "hello\n");

--- a/tests/_exe/indirect-calls.golden
+++ b/tests/_exe/indirect-calls.golden
@@ -10,6 +10,8 @@ indirect
 indirect
 indirect
 indirect
+fun1
+fun4
 hello
 hello
 hello


### PR DESCRIPTION
The value_type function, which determines the type of an expression, did not handle indirect function calls properly. This caused errors when trying to call functions through function pointers obtained from non-literal expressions such as: `get_function_pointer()();`