### PR TITLE
Fix sign-extension of 64-bit literals

### DIFF
--- a/exe.c
+++ b/exe.c
@@ -132,8 +132,9 @@ void emit_i32_le(int n) {
 
 void emit_i64_le(int n) {
   emit_i32_le(n);
-  // Sign extend to 64 bits. Arithmetic shift by 31 gives -1 for negative numbers and 0 for positive numbers.
-  emit_i32_le(n >> 31);
+  // Sign extend to 64 bits. Because int is not guaranteed to be exactly 32
+  // bits, we check the 32th bit (sign bit) and fill with 0xff... if set.
+  emit_i32_le(TERNARY(n & 0x80000000, -1, 0));
 }
 
 #ifdef SUPPORT_64_BIT_LITERALS


### PR DESCRIPTION
# Context

When `SUPPORT_64_BIT_LITERALS` is not enabled, `INTEGER` nodes store the negation of the integer value. This is done to support the full range of 32-bit signed integers, since the positive value `2147483648` cannot be represented as a positive signed 32-bit integer.

To get the actual value, it must be negated. If the negated value is `-2147483648`, negating it produces `2147483648`, which overflows the 32-bit signed integer range (assuming the host platform uses 32-bit integers) and loops back to `-2147483648`. Additionally, for 64-bit targets, the value must be sign-extended to 64-bits, which is done by left shifting by 31.

On platforms with 32-bit integers, the two's complement representation of 2147483648 is the same as -2147483648's two's complement, 0x80000000 in hex, and so everything works out.

On platforms with larger integers, such as some shells, the value `2147483648` is representable as a positive integer, and so negating `-2147483648` produces `2147483648`, which produces an invalid sign-extended value when shifted. Sign-extension is only performed when targeting 64-bit platforms, where `2147483648 >> 31` evaluates to 1.

This PR changes the sign-extension to no longer assume exactly 32-bit integers.