### PR TITLE
pnut-awk: use printf built-in for put{int,hex,oct}

### DIFF
--- a/pnut.c
+++ b/pnut.c
@@ -403,11 +403,16 @@ void putstr(char *str) {
   }
 }
 
-#ifdef PNUT_SH
+#if defined(PNUT_SH) || defined(PNUT_AWK)
+// When compiling pnut-sh or pnut-awk, we use the built-in printf function to
+// output integers in decimal, hex and octal.
+
 #define putint(n) printf("%d", n)
 #define puthex_unsigned(n) printf("%x", n)
 #define putoct_unsigned(n) printf("%o", n)
+
 #else
+
 void putint_aux(int n) {
   if (n <= -10) putint_aux(n / 10);
   putchar('0' - (n % 10));
@@ -423,7 +428,7 @@ void putint(int n) {
   }
 }
 
-#ifdef target_sh
+#if defined(target_sh) || defined(target_awk)
 
 // Output unsigned integer in hex
 void puthex_unsigned(int n) {
@@ -438,9 +443,9 @@ void putoct_unsigned(int n) {
   if ((n >> 3) & 0x1fffffff) putoct_unsigned((n >> 3) & 0x1fffffff);
   putchar('0' + (n & 7));
 }
-#endif
+#endif // defined(target_sh) || defined(target_awk)
 
-#endif
+#endif // defined(PNUT_SH) || defined(PNUT_AWK)
 
 #ifdef NICE_ERR_MSG
 
@@ -1624,6 +1629,10 @@ void u64_to_obj(int *x) {
   if (x[0] >= 0 && x[1] == 0) { // "small int"
     val = -x[0];
   } else {
+    // putstr("0x");
+    // puthex_unsigned(x[1]);
+    // puthex_unsigned(x[0]);
+    // putchar('\n');
     val = alloc_obj(2);
     heap[val    ] = x[0];
     heap[val + 1] = x[1];


### PR DESCRIPTION
Cuts the number of lines in pnut-awk generated scripts by up to 30 lines.

Before:
```
  Variant                C     Clean  Preproc  .sh   Runtime  Blank  .awk  R(C)  R(clean)  R(preproc)
  pnut-sh (min)          9172  6995   4214     6133  430      236    4858  .668  .876      1.455
  pnut-sh                9172  6995   5242     7644  517      265    6039  .833  1.092     1.458
  pnut-awk (min)         7460  5599   3569     5338  428      220    4224  .715  .953      1.495
  pnut-awk               7460  5599   4202     6293  515      241    4874  .843  1.123     1.497
  pnut-i386_linux (min)  9978  7129   4089     5713  432      292    4622  .572  .801      1.397
  pnut-i386_linux        9978  7129   5233     7356  509      336    5817  .737  1.031     1.405
```

Now:
```
  Variant                C     Clean  Preproc  .sh   Runtime  Blank  .awk  R(C)  R(clean)  R(preproc)
  pnut-sh (min)          9181  6995   4214     6133  430      236    4828  .668  .876      1.455
  pnut-sh                9181  6995   5242     7644  517      265    6009  .832  1.092     1.458
  pnut-awk (min)         7469  5599   3577     5338  428      220    4208  .714  .953      1.492
  pnut-awk               7469  5599   4210     6293  515      241    4858  .842  1.123     1.494
  pnut-i386_linux (min)  9987  7129   4089     5713  432      292    4606  .572  .801      1.397
  pnut-i386_linux        9987  7129   5233     7356  509      336    5801  .736  1.031     1.405
```