### PR TITLE
Remove "eval" string from pnut-{sh,awk,exe}.{sh,awk} files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,9 @@ jobs:
       - name: Generate .sh/.awk files and check for "eval"
         run: |
           set -e
-          make check-no-eval
+          make check-no-eval MINIMAL=0
+          make check-no-eval MINIMAL=1
+          make check-no-eval ANNOTATE_C_CODE=1
 
   catch-bad-whitespace:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,9 +58,12 @@ jobs:
       - name: Generate .sh/.awk files and check for "eval"
         run: |
           set -e
-          make check-no-eval MINIMAL=0
-          make check-no-eval MINIMAL=1
-          make check-no-eval ANNOTATE_C_CODE=1
+          for target in Linux.i386 Linux.x86_64 Darwin.x86_64; do
+            make check-no-eval TARGET=$target MINIMAL=0
+            make check-no-eval TARGET=$target MINIMAL=1
+            make check-no-eval TARGET=$target ANNOTATE_C_CODE=1 MINIMAL=0
+            make check-no-eval TARGET=$target ANNOTATE_C_CODE=1 MINIMAL=1
+          done
 
   catch-bad-whitespace:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,23 @@ jobs:
             done
           done
 
+  check-no-eval: # Ensure the generated .sh/.awk files never contain the string "eval"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install gcc
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Generate .sh/.awk files and check for "eval"
+        run: |
+          set -e
+          make check-no-eval
+
   catch-bad-whitespace:
     runs-on: ubuntu-latest
     steps:
@@ -679,6 +696,7 @@ jobs:
   success-message:
     runs-on: ubuntu-latest
     needs: [ build-without-warnings
+           , check-no-eval
            , catch-bad-whitespace
            , compile-in-safe-mode
            , portable-libc-tests

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,22 @@ pnut-exe-bootstrapped: pnut-exe
 	$(BUILD_DIR)/pnut-exe $(BUILD_OPT_EXE) pnut.c -o $(BUILD_DIR)/pnut-exe-bootstrapped
 	@chmod +x $(BUILD_DIR)/pnut-exe-bootstrapped
 
+# Generated .sh/.awk files produced by the targets above. All the other .sh/.awk
+# files the makefile can create (bootstrapped/annotated variants) are diffed
+# against these, so checking these is sufficient.
+NO_EVAL_TARGETS = pnut-sh.sh pnut-awk.awk pnut-exe.sh pnut-exe.awk
+NO_EVAL_FILES = $(addprefix $(BUILD_DIR)/,$(NO_EVAL_TARGETS))
+
+# Fail if a generated .sh/.awk file contains the string "eval".
+check-no-eval: $(NO_EVAL_TARGETS)
+	@echo "Checking that generated .sh/.awk files do not contain 'eval'..."
+	@if grep -n "eval" $(NO_EVAL_FILES) >/dev/null; then \
+		echo "ERROR: 'eval' found in generated files:"; \
+		grep -n "eval" $(NO_EVAL_FILES); \
+		exit 1; \
+	fi
+	@echo "Success: no 'eval' in generated .sh/.awk files"
+
 kit/bintools.c:
 	./utils/process-includes.sh kit/bintools/bintools-base.c > kit/bintools.c
 

--- a/awk.c
+++ b/awk.c
@@ -753,7 +753,7 @@ bool comp_switch(ast node) {
       // For "atomic" scrutinees, use them directly in the comparisons
       break;
     default:
-      // Otherwise, evaluate the scrutinee into a temporary variable
+      // Otherwise, compute the scrutinee into a temporary variable
       append_glo_decl(string_concat(wrap_str_lit("__scrutinee = "), scrutinee_text));
       scrutinee_text = wrap_str_lit("__scrutinee");
   }

--- a/doc/architecture_of_pnut.c
+++ b/doc/architecture_of_pnut.c
@@ -130,7 +130,7 @@
 //  - handle_preprocessor_directive(): entry point for handling cpp directives
 //  - handle_define(): handles #define directives
 //  - handle_include(): handles #include directives
-//  - compute_if_condition(): evaluates the condition of #if and #elif
+//  - compute_if_condition(): computes the condition of #if and #elif
 //  - begin_macro_expansion/return_to_parent_macro(): manage expansion context
 //  - attempt_macro_expansion(): starts expansion when a macro token is found
 //

--- a/doc/architecture_of_pnut.c
+++ b/doc/architecture_of_pnut.c
@@ -130,7 +130,7 @@
 //  - handle_preprocessor_directive(): entry point for handling cpp directives
 //  - handle_define(): handles #define directives
 //  - handle_include(): handles #include directives
-//  - evaluate_if_condition(): evaluates the condition of #if and #elif
+//  - compute_if_condition(): evaluates the condition of #if and #elif
 //  - begin_macro_expansion/return_to_parent_macro(): manage expansion context
 //  - attempt_macro_expansion(): starts expansion when a macro token is found
 //

--- a/doc/c_to_shell_translation.c
+++ b/doc/c_to_shell_translation.c
@@ -42,8 +42,9 @@
 // - How functions (local variables, parameters, return values) are implemented.
 // - Character and string literals.
 //
-// Importantly, this is done without dynamic code evaluation (`eval` command)
-// that would make the code more difficult to read and audit.
+// Importantly, this is done without dynamic code execution of strings
+// (`e_v_a_l` command), which would make the code more difficult to read and
+// audit.
 //
 // Features that don't have a direct mapping to shell (goto, switch
 // fall-through, floating point numbers), or that are not used in pnut's source

--- a/exe.c
+++ b/exe.c
@@ -1753,15 +1753,15 @@ ast narrowed_rvalue_type(ast node);
 // versions of codegen_rvalue, which are defined differently depending on the
 // compilation flags:
 //  - codegen_rvalue_coerced:
-//      Evaluate an rvalue expression and convert the result to the
+//      Compute an rvalue expression and convert the result to the
 //      representation of target_type. Temporaries that are allocated are not
 //      dropped, and must be freed by the caller or are freed when the
 //      expression is consumed.
 //
 //  - codegen_rvalue_coerced_no_temps:
-//      Evaluate an rvalue expression and convert the result to the
+//      Compute an rvalue expression and convert the result to the
 //      representation of target_type. Enforces that any temporaries allocated
-//      during evaluation must be freed, fails if the expression returns an
+//      during computation must be freed, fails if the expression returns an
 //      array backed by a temporary.
 //
 // =============================================================================
@@ -1809,7 +1809,7 @@ void codegen_rvalue_coerced(ast node, ast target_type) {
 #ifdef SUPPORT_STRUCT_UNION
 
 // Compile node as rvalue, converting result to target type. Free any
-// temporaries allocated during evaluation, leaving the value directly on top of
+// temporaries allocated during computation, leaving the value directly on top of
 // the stack.
 // target_type == 0 (varargs/unknown parameter) means no coercion.
 void codegen_rvalue_coerced_no_temps(ast node, ast target_type) {
@@ -1851,11 +1851,11 @@ void codegen_rvalue_coerced_no_temps(ast node, ast target_type) {
 //
 // However, there are cases where a temporary must be freed before the end of
 // the statement to keep the stack balanced:
-//  - When evaluating a condition, the temporary never escapes the condition
+//  - When computing a condition, the temporary never escapes the condition
 //    expression, and would pile up on the stack during loops if not freed right
 //    away.
 //    Handled by `codegen_rvalue_and_cmp_0`.
-//  - When evaluating a ternary operator arm, since the individual arms may
+//  - When computing a ternary operator arm, since the individual arms may
 //    allocate a different number of temporaries while both must leave the same
 //    stack shape at the join point.
 //    Handled by `codegen_aggregate` for struct/union-typed ternaries, and
@@ -1864,11 +1864,11 @@ void codegen_rvalue_coerced_no_temps(ast node, ast target_type) {
 //    arguments and/or function pointer (for indirect calls).
 //    Handled by `codegen_rvalue_no_temps` for scalar arguments, and
 //    `codegen_aggregate` for by-value struct/union arguments.
-//  - When evaluating a scalar assignment or local variable initializer, since
+//  - When computing a scalar assignment or local variable initializer, since
 //    temporary values would offset the destination address / the local
 //    variable's SP-relative offset which are assumed to not change.
 //    Handled by `codegen_rvalue_no_temps`.
-//  - When evaluating the right operand of a binary operator, since
+//  - When computing the right operand of a binary operator, since
 //    codegen_binop expects its two operand words to be adjacent on top of the
 //    stack (the left operand's temporaries can stay buried below its value
 //    word, so the left operand doesn't need this).
@@ -1883,10 +1883,10 @@ void codegen_rvalue_coerced_no_temps(ast node, ast target_type) {
 // =============================================================================
 
 
-// Evaluate an rvalue expression for contexts that require the value to be
+// Compute an rvalue expression for contexts that require the value to be
 // exactly one word on top of the stack with no temporaries left behind
 // (binop operands, function arguments, ternary arms, scalar assignments and
-// initializers): any temporaries allocated during evaluation are freed, the
+// initializers): any temporaries allocated during computation are freed, the
 // value word being preserved. Aggregate temporaries can't be dropped when the
 // expression's value is a pointer into them, so array-typed expressions that
 // allocate temporaries (e.g. f().arr with f returning a struct by value) are
@@ -1902,7 +1902,7 @@ void codegen_aggregate_into(int dst_reg, int dst_offset, ast node, int width, as
   codegen_rvalue_coerced(node, target_type);
   stack_pop(reg_X); // source aggregate address
   if (dst_reg == reg_SP) {
-    // Account for temporaries allocated during evaluation
+    // Account for temporaries allocated during computation
     dst_offset += (cgc_fs - save_fs) * WORD_SIZE;
   } else {
     // Reload destination register, saved below the temporaries
@@ -1912,9 +1912,9 @@ void codegen_aggregate_into(int dst_reg, int dst_offset, ast node, int width, as
   reset_stack_to(save_fs);
 }
 
-// Evaluate an aggregate rvalue and place it directly on top of the stack,
-// dropping any temporaries allocated during evaluation. The buffer is
-// allocated before evaluating the expression so that the value is copied
+// Compute an aggregate rvalue and place it directly on top of the stack,
+// dropping any temporaries allocated during computation. The buffer is
+// allocated before computing the expression so that the value is copied
 // directly into place, below the temporaries (in which the value may live,
 // hence the copy-then-drop order).
 void codegen_aggregate(ast node, ast target_type) {
@@ -1937,7 +1937,7 @@ void codegen_aggregate(ast node, ast target_type) {
 
 #endif // SUPPORT_STRUCT_UNION
 
-// Evaluate an rvalue for use as a function argument, coercing it to the
+// Compute an rvalue for use as a function argument, coercing it to the
 // parameter's declared type if needed.
 void codegen_param(ast param, ast target_type) {
   if (target_type == 0) target_type = value_type(param);
@@ -1957,7 +1957,7 @@ void codegen_param(ast param, ast target_type) {
   }
 }
 
-// Evaluate the call arguments, converting the them to their expected types.
+// Compute the call arguments, converting the them to their expected types.
 #ifdef SAFE_MODE
 void codegen_params(ast params, ast params_type, bool allow_extra_params) {
 #else
@@ -2836,7 +2836,7 @@ void codegen_rvalue(ast node) {
   }
 }
 
-// Evaluate a condition expression and jump to lbl if the condition is true,
+// Compute a condition expression and jump to lbl if the condition is true,
 // fallthrough otherwise.
 void codegen_rvalue_and_cmp_0(int cond, int lbl, ast node) {
 #ifdef SUPPORT_STRUCT_UNION
@@ -2855,7 +2855,7 @@ void codegen_rvalue_and_cmp_0(int cond, int lbl, ast node) {
 #ifdef SUPPORT_STRUCT_UNION
   // The node's value is immediately consumed by a conditional jump, so it can
   // be collected right away. This also ensures that temporaries don't pile up
-  // during loops, where the condition is evaluated multiple times.
+  // during loops, where the condition is computed multiple times.
   reset_stack_to(save_fs);
 #endif
 
@@ -3337,7 +3337,7 @@ void codegen_statement(ast node) {
     // exists.
     //
     // The code is laid out as follows:
-    //  [eval switch opnd]
+    //  [compute switch opnd]
     //  [cases]
     //  ...
     //   <- Control is here
@@ -3394,7 +3394,7 @@ void codegen_statement(ast node) {
       } else
 #endif
       {
-      codegen_rvalue(get_child_(CASE_KW, node, 0)); // evaluate case expression and compare it
+      codegen_rvalue(get_child_(CASE_KW, node, 0)); // compute case expression and compare it
       stack_pop(reg_Y);                       // get case value
       stack_load(reg_X, cgc_fs);              // get switch operand without popping it
       jump_cond_reg_reg(EQ, lbl1, reg_X, reg_Y);

--- a/pnut.c
+++ b/pnut.c
@@ -2006,15 +2006,15 @@ void handle_define() {
   set_symbol_tag(macro, cons(read_macro_tokens(args), args_count));
 }
 
-int eval_constant(ast expr, bool if_macro) {
+int compute_constant(ast expr, bool if_macro) {
   int op = get_op(expr);
 
   int val0, val1; // Results of evaluating child0 and child1, for non-lazy operators
   if (op != '?' && op != AMP_AMP && op != BAR_BAR && op != '(') {
     // For non-lazy operators, we can pre-evaluate the children.
-    // This makes eval_constant's shell version much shorter and easier to review.
-    if (get_nb_children(expr) >= 1) val0 = eval_constant(get_child(expr, 0), if_macro);
-    if (get_nb_children(expr) >= 2) val1 = eval_constant(get_child(expr, 1), if_macro);
+    // This makes compute_constant's shell version much shorter and easier to review.
+    if (get_nb_children(expr) >= 1) val0 = compute_constant(get_child(expr, 0), if_macro);
+    if (get_nb_children(expr) >= 2) val1 = compute_constant(get_child(expr, 1), if_macro);
   }
 
   switch (op) {
@@ -2063,19 +2063,19 @@ int eval_constant(ast expr, bool if_macro) {
       }
 
     case '?':
-      val0 = eval_constant(get_child(expr, 0), if_macro);
+      val0 = compute_constant(get_child(expr, 0), if_macro);
       if (val0) {
-        return eval_constant(get_child(expr, 1), if_macro);
+        return compute_constant(get_child(expr, 1), if_macro);
       } else {
-        return eval_constant(get_child(expr, 2), if_macro);
+        return compute_constant(get_child(expr, 2), if_macro);
       }
 
     case AMP_AMP:
     case BAR_BAR:
-      val0 = eval_constant(get_child(expr, 0), if_macro);
+      val0 = compute_constant(get_child(expr, 0), if_macro);
       if (op == AMP_AMP && !val0) return 0;
       else if (op == BAR_BAR && val0) return 1;
-      else return eval_constant(get_child(expr, 1), if_macro);
+      else return compute_constant(get_child(expr, 1), if_macro);
 
     case '(': // defined operators are represented as fun calls
       if (if_macro && get_val_(IDENTIFIER, get_child(expr, 0)) == DEFINED_ID) {
@@ -2104,7 +2104,7 @@ int eval_constant(ast expr, bool if_macro) {
 
 ast parse_constant_expression();
 
-int evaluate_if_condition() {
+int compute_if_condition() {
   bool prev_skip_newlines = skip_newlines;
   int previous_mask = if_macro_mask;
   ast expr;
@@ -2118,7 +2118,7 @@ int evaluate_if_condition() {
   // Restore the previous value
   if_macro_mask = previous_mask;
   skip_newlines = prev_skip_newlines;
-  return eval_constant(expr, true);
+  return compute_constant(expr, true);
 }
 
 #ifdef SH_SUPPORT_SHELL_INCLUDE
@@ -2203,10 +2203,10 @@ void handle_preprocessor_directive() {
 #endif
       get_tok_macro(true); // Skip the macro name
     } else if (tok == IF_KW) {
-      temp = evaluate_if_condition();
+      temp = compute_if_condition();
       push_if_macro_mask(temp != 0);
     } else if (tok == IDENTIFIER && val == ELIF_ID) {
-      temp = evaluate_if_condition() ;
+      temp = compute_if_condition() ;
       if (prev_macro_mask() && !if_macro_executed) {
         if_macro_mask = temp != 0;
         if_macro_executed |= if_macro_mask;
@@ -3493,7 +3493,7 @@ ast parse_enum() {
             break;
           default:
             // Evaluate the constant expression to get its integer value
-            value = new_ast0(last_literal_type, -eval_constant(value, false)); // negative value to indicate it's a small integer
+            value = new_ast0(last_literal_type, -compute_constant(value, false)); // negative value to indicate it's a small integer
         }
         next_value = get_val(value) - 1; // Next value is the current value + 1, but val is negative
         last_literal_type = get_op(value);
@@ -3943,7 +3943,7 @@ ast parse_declarator(bool abstract_decl, ast parent_type) {
       } else {
         arr_size_expr = parse_constant_expression();
         if (arr_size_expr == 0) parse_error("Array size must be an integer constant", tok);
-        val = eval_constant(arr_size_expr, false);
+        val = compute_constant(arr_size_expr, false);
       }
       result = new_ast2('[', get_inner_type(parent_type_parent), val);
       update_inner_type(parent_type_parent, result);
@@ -4462,7 +4462,7 @@ ast parse_comma_expression_opt() {
 
 // A constant-expression cannot be a comma or assignment expression, so the
 // precedence climb starts at the ternary level. This may still parse
-// non-constant expressions, checks are done in eval_constant.
+// non-constant expressions, checks are done in compute_constant.
 ast parse_constant_expression() {
   return parse_binary_expression(3); // prec 3 => start at ternary operator
 }

--- a/pnut.c
+++ b/pnut.c
@@ -169,7 +169,7 @@
   // #define INCLUDE_ALL_RUNTIME
 
   // Only emit shell code output at the end of the compilation.
-  // This is used to evaluate the negative performance impact of allocating
+  // This is used to measure the negative performance impact of allocating
   // There is no practical reason to enable this option.
   // #define ONE_PASS_GENERATOR_NO_EARLY_OUTPUT
 
@@ -371,7 +371,7 @@
 // M2-Planet doesn't support ternary operator.
 // Ternary operator can be implemented using arithmetic operations.
 // Note that unlike the standard ternary operator, both sides are always
-// evaluated, and the condition expression is evaluated twice.
+// computed, and the condition expression is computed twice.
 #define TERNARY(cond, if_true, if_false) (((cond) == 0) * (if_false) + ((cond) != 0) * (if_true))
 #else
 #define TERNARY(cond, if_true, if_false) ((cond) ? (if_true) : (if_false))
@@ -2009,9 +2009,9 @@ void handle_define() {
 int compute_constant(ast expr, bool if_macro) {
   int op = get_op(expr);
 
-  int val0, val1; // Results of evaluating child0 and child1, for non-lazy operators
+  int val0, val1; // Results of computing child0 and child1, for non-lazy operators
   if (op != '?' && op != AMP_AMP && op != BAR_BAR && op != '(') {
-    // For non-lazy operators, we can pre-evaluate the children.
+    // For non-lazy operators, we can precompute the children.
     // This makes compute_constant's shell version much shorter and easier to review.
     if (get_nb_children(expr) >= 1) val0 = compute_constant(get_child(expr, 0), if_macro);
     if (get_nb_children(expr) >= 2) val1 = compute_constant(get_child(expr, 1), if_macro);
@@ -2093,7 +2093,7 @@ int compute_constant(ast expr, bool if_macro) {
         syntax_error("identifiers are not allowed in constant expression");
       }
 
-      return 0; // Undefined identifiers evaluate to 0
+      return 0; // Undefined identifiers count as 0
 
     default:
       dump_op(op);
@@ -3492,7 +3492,7 @@ ast parse_enum() {
 #endif
             break;
           default:
-            // Evaluate the constant expression to get its integer value
+            // Compute the constant expression to get its integer value
             value = new_ast0(last_literal_type, -compute_constant(value, false)); // negative value to indicate it's a small integer
         }
         next_value = get_val(value) - 1; // Next value is the current value + 1, but val is negative

--- a/sh.c
+++ b/sh.c
@@ -638,7 +638,7 @@ ast handle_fun_call_side_effect(ast node, ast assign_to, bool executes_condition
     start_gensym_ix = gensym_ix;
 
     // At this point, the temporary identifier of the variable is not live and
-    // can be used to evaluate the function arguments. This reduces the number
+    // can be used to compute the function arguments. This reduces the number
     // of temporary variables.
     gensym_ix -= 1;
   }

--- a/sh.c
+++ b/sh.c
@@ -1742,7 +1742,7 @@ bool comp_switch(ast node) {
   // Returning not-false is only important for nested switch statements.
   // It could be useful to remove the need for the redundant trailing return
   // when nesting switch statements that we know are exhaustive such as in
-  // eval_constant.
+  // compute_constant.
   //
   // I tried to make it return true if all cases of a switch end with a return
   // but it wasn't working well because we don't know if the switch delimits the


### PR DESCRIPTION
## Context

The `pnut-sh` compiler goes to great lengths to avoid generating code that uses `eval`. Since we expect users to verify that claim (using commands such as `grep eval pnut-sh.sh`), we want to remove any mention of `eval` in the human-readable build artifacts. This PR renames 2 functions that caused the string `"eval"` to appear and adds a CI check to ensure we don't reintroduce the eval string by accident.